### PR TITLE
chore: temporarily disable pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,9 +1,9 @@
 # checks that pre-commit hooks pass before allowing to merge a PR
 
 name: pre-commit
-on:
-  pull_request:
-    branches: [main, master, staging, dev, feat/**, fix/**]
+# on:
+#   pull_request:
+#     branches: [main, master, staging, dev, feat/**, fix/**]
 
 jobs:
   pre-commit:


### PR DESCRIPTION
`forge doc` is non determinsticaly generating files causing really difficult diffs and merge conflicts. Disable for now and re-enable later