### PR TITLE
OZ(L-17): Make most abstract contract state variables private and add `$_` prefix

### DIFF
--- a/snapshots/AuctionTest.json
+++ b/snapshots/AuctionTest.json
@@ -1,13 +1,13 @@
 {
-  "checkpoint_advanceToCurrentStep": "149324",
-  "checkpoint_noBids": "132966",
-  "checkpoint_zeroSupply": "136756",
-  "claimTokens": "83625",
-  "exitBid": "66461",
-  "exitPartiallyFilledBid": "237695",
-  "submitBid": "150800",
-  "submitBid_recordStep_updateCheckpoint": "299348",
-  "submitBid_recordStep_updateCheckpoint_initializeTick": "299348",
-  "submitBid_updateCheckpoint": "264664",
-  "submitBid_withValidationHook": "303487"
+  "checkpoint_advanceToCurrentStep": "148929",
+  "checkpoint_noBids": "132703",
+  "checkpoint_zeroSupply": "136421",
+  "claimTokens": "83496",
+  "exitBid": "66353",
+  "exitPartiallyFilledBid": "237237",
+  "submitBid": "150680",
+  "submitBid_recordStep_updateCheckpoint": "299072",
+  "submitBid_recordStep_updateCheckpoint_initializeTick": "299072",
+  "submitBid_updateCheckpoint": "264376",
+  "submitBid_withValidationHook": "303211"
 }

--- a/src/AuctionStepStorage.sol
+++ b/src/AuctionStepStorage.sol
@@ -21,9 +21,9 @@ abstract contract AuctionStepStorage is IAuctionStepStorage {
     uint256 private immutable _length;
 
     /// @notice The address pointer to the contract deployed by SSTORE2
-    address public $pointer;
+    address private $_pointer;
     /// @notice The word offset of the last read step in `auctionStepsData` bytes
-    uint256 public $offset;
+    uint256 private $_offset;
     /// @notice The current active auction step
     AuctionStep internal $step;
 
@@ -37,7 +37,7 @@ abstract contract AuctionStepStorage is IAuctionStepStorage {
         if (_pointer == address(0)) revert InvalidPointer();
 
         _validate(_pointer);
-        $pointer = _pointer;
+        $_pointer = _pointer;
 
         _advanceStep();
     }
@@ -66,9 +66,9 @@ abstract contract AuctionStepStorage is IAuctionStepStorage {
     /// @notice Advance the current auction step
     /// @dev This function is called on every new bid if the current step is complete
     function _advanceStep() internal returns (AuctionStep memory) {
-        if ($offset > _length) revert AuctionIsOver();
+        if ($_offset > _length) revert AuctionIsOver();
 
-        bytes8 _auctionStep = bytes8($pointer.read($offset, $offset + UINT64_SIZE));
+        bytes8 _auctionStep = bytes8($_pointer.read($_offset, $_offset + UINT64_SIZE));
         (uint24 mps, uint40 blockDelta) = _auctionStep.parse();
 
         uint64 _startBlock = $step.endBlock;
@@ -77,7 +77,7 @@ abstract contract AuctionStepStorage is IAuctionStepStorage {
 
         $step = AuctionStep({startBlock: _startBlock, endBlock: _endBlock, mps: mps});
 
-        $offset += UINT64_SIZE;
+        $_offset += UINT64_SIZE;
 
         emit AuctionStepRecorded(_startBlock, _endBlock, mps);
         return $step;

--- a/src/BidStorage.sol
+++ b/src/BidStorage.sol
@@ -6,15 +6,15 @@ import {Bid} from './libraries/BidLib.sol';
 
 abstract contract BidStorage is IBidStorage {
     /// @notice The id of the next bid to be created
-    uint256 internal $nextBidId;
+    uint256 private $_nextBidId;
     /// @notice The mapping of bid ids to bids
-    mapping(uint256 bidId => Bid bid) public $bids;
+    mapping(uint256 bidId => Bid bid) private $_bids;
 
     /// @notice Get a bid from storage
     /// @param bidId The id of the bid to get
     /// @return bid The bid
     function _getBid(uint256 bidId) internal view returns (Bid memory) {
-        return $bids[bidId];
+        return $_bids[bidId];
     }
 
     /// @notice Create a new bid
@@ -37,32 +37,32 @@ abstract contract BidStorage is IBidStorage {
             tokensFilled: 0
         });
 
-        bidId = $nextBidId;
-        $bids[bidId] = bid;
-        $nextBidId++;
+        bidId = $_nextBidId;
+        $_bids[bidId] = bid;
+        $_nextBidId++;
     }
 
     /// @notice Update a bid in storage
     /// @param bidId The id of the bid to update
     /// @param bid The new bid
     function _updateBid(uint256 bidId, Bid memory bid) internal {
-        $bids[bidId] = bid;
+        $_bids[bidId] = bid;
     }
 
     /// @notice Delete a bid from storage
     /// @param bidId The id of the bid to delete
     function _deleteBid(uint256 bidId) internal {
-        delete $bids[bidId];
+        delete $_bids[bidId];
     }
 
     /// Getters
     /// @inheritdoc IBidStorage
     function nextBidId() external view override(IBidStorage) returns (uint256) {
-        return $nextBidId;
+        return $_nextBidId;
     }
 
     /// @inheritdoc IBidStorage
     function bids(uint256 bidId) external view override(IBidStorage) returns (Bid memory) {
-        return $bids[bidId];
+        return $_bids[bidId];
     }
 }

--- a/src/CheckpointStorage.sol
+++ b/src/CheckpointStorage.sol
@@ -23,9 +23,9 @@ abstract contract CheckpointStorage is ICheckpointStorage {
     uint64 public constant MAX_BLOCK_NUMBER = type(uint64).max;
 
     /// @notice Storage of checkpoints
-    mapping(uint64 blockNumber => Checkpoint) internal $checkpoints;
+    mapping(uint64 blockNumber => Checkpoint) private $_checkpoints;
     /// @notice The block number of the last checkpointed block
-    uint64 public $lastCheckpointedBlock;
+    uint64 internal $lastCheckpointedBlock;
 
     /// @inheritdoc ICheckpointStorage
     function latestCheckpoint() public view returns (Checkpoint memory) {
@@ -44,17 +44,17 @@ abstract contract CheckpointStorage is ICheckpointStorage {
 
     /// @notice Get a checkpoint from storage
     function _getCheckpoint(uint64 blockNumber) internal view returns (Checkpoint memory) {
-        return $checkpoints[blockNumber];
+        return $_checkpoints[blockNumber];
     }
 
     /// @notice Insert a checkpoint into storage
     /// @dev This function updates the prev and next pointers of the latest checkpoint and the new checkpoint
     function _insertCheckpoint(Checkpoint memory checkpoint, uint64 blockNumber) internal {
         uint64 _lastCheckpointedBlock = $lastCheckpointedBlock;
-        if (_lastCheckpointedBlock != 0) $checkpoints[_lastCheckpointedBlock].next = blockNumber;
+        if (_lastCheckpointedBlock != 0) $_checkpoints[_lastCheckpointedBlock].next = blockNumber;
         checkpoint.prev = _lastCheckpointedBlock;
         checkpoint.next = MAX_BLOCK_NUMBER;
-        $checkpoints[blockNumber] = checkpoint;
+        $_checkpoints[blockNumber] = checkpoint;
         $lastCheckpointedBlock = blockNumber;
     }
 
@@ -133,6 +133,6 @@ abstract contract CheckpointStorage is ICheckpointStorage {
 
     /// @inheritdoc ICheckpointStorage
     function checkpoints(uint64 blockNumber) external view override(ICheckpointStorage) returns (Checkpoint memory) {
-        return $checkpoints[blockNumber];
+        return $_checkpoints[blockNumber];
     }
 }


### PR DESCRIPTION
All mappings are private, and state variables only used within abstract contracts. Only exceptions are `$step`, `$nextActiveTickPrice`, and `$lastCheckpointedBlock` since they are used frequently in the Auction contract and I don't think the gas overhead from doing a func call is worth it