### PR TITLE
chore: add sender in factory prediction

### DIFF
--- a/src/AuctionFactory.sol
+++ b/src/AuctionFactory.sol
@@ -33,7 +33,7 @@ contract AuctionFactory is IAuctionFactory {
     }
 
     /// @inheritdoc IAuctionFactory
-    function getAuctionAddress(address token, uint256 amount, bytes calldata configData, bytes32 salt)
+    function getAuctionAddress(address token, uint256 amount, bytes calldata configData, bytes32 salt, address sender)
         public
         view
         returns (address)
@@ -47,7 +47,7 @@ contract AuctionFactory is IAuctionFactory {
 
         bytes32 initCodeHash =
             keccak256(abi.encodePacked(type(Auction).creationCode, abi.encode(token, uint128(amount), parameters)));
-        salt = keccak256(abi.encode(msg.sender, salt));
+        salt = keccak256(abi.encode(sender, salt));
         return Create2.computeAddress(salt, initCodeHash, address(this));
     }
 }

--- a/src/interfaces/IAuctionFactory.sol
+++ b/src/interfaces/IAuctionFactory.sol
@@ -20,8 +20,9 @@ interface IAuctionFactory is IDistributionStrategy {
     /// @param amount The amount of tokens to sell
     /// @param configData The configuration data for the auction
     /// @param salt The salt to use for the deterministic deployment
+    /// @param sender The sender of the initializeDistribution transaction
     /// @return The address of the auction contract
-    function getAuctionAddress(address token, uint256 amount, bytes calldata configData, bytes32 salt)
+    function getAuctionAddress(address token, uint256 amount, bytes calldata configData, bytes32 salt, address sender)
         external
         view
         returns (address);

--- a/test/AuctionFactory.t.sol
+++ b/test/AuctionFactory.t.sol
@@ -217,8 +217,8 @@ contract AuctionFactoryTest is TokenHandler, Test, Assertions {
         vm.assume(_token != address(0));
         vm.assume(_params.currency != address(0));
         vm.assume(_token != _params.currency);
-        vm.assume(_params.tokensRecipient != address(0));
-        vm.assume(_params.fundsRecipient != address(0));
+        vm.assume(_params.tokensRecipient > address(1));
+        vm.assume(_params.fundsRecipient > address(1));
         vm.assume(_params.startBlock != 0);
         vm.assume(_params.claimBlock != 0);
 
@@ -258,16 +258,19 @@ contract AuctionFactoryTest is TokenHandler, Test, Assertions {
         uint128 _totalSupply,
         bytes32 _salt,
         uint8 _numberOfSteps,
+        address _sender,
         AuctionParameters memory _params
     ) public {
         helper__assumeValidDeploymentParams(_token, _totalSupply, _salt, _params, _numberOfSteps);
+        vm.assume(_sender > address(1)); 
 
         bytes memory configData = abi.encode(_params);
 
         // Predict the auction address
-        address auctionAddress = factory.getAuctionAddress(_token, _totalSupply, configData, _salt);
+        address auctionAddress = factory.getAuctionAddress(_token, _totalSupply, configData, _salt, _sender);
 
         // Create the actual auction
+        vm.prank(_sender);
         IDistributionContract distributionContract =
             factory.initializeDistribution(_token, _totalSupply, configData, _salt);
 


### PR DESCRIPTION
# Overview

Previous implementation did not take into account predicting addresses when deployments will come from other factories
