### PR TITLE
fix: move currencyRaised* values to 128.128 form

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ type ValueX7X7 is uint256;
 
 **Use Cases**:
 
-- Total currency raised tracking (`currencyRaisedX7`)
+- Total currency raised tracking (`currencyRaisedX128_X7`)
 - Supply rollover calculations when auctions become fully subscribed
 - Complex time-weighted average price calculations
 
@@ -295,7 +295,7 @@ Once fully subscribed, we freeze this ratio. Both numerator (actual currency) an
 **Implementation:**
 
 ```solidity
-currencyRaisedX7X7 = cachedRemainingCurrencyRaisedX7X7.wrapAndFullMulDiv(
+currencyRaisedX128_X7X7 = cachedRemainingCurrencyRaisedX7X7.wrapAndFullMulDiv(
     clearingPrice * deltaMps,
     cachedRemainingPercentage * FLOOR_PRICE
 );
@@ -465,10 +465,10 @@ event BidExited(uint256 indexed bidId, address indexed owner, uint256 tokensFill
 - `lower`: Last checkpoint where clearing price is strictly < bid.maxPrice
 - `upper`: First checkpoint where clearing price is strictly > bid.maxPrice, or 0 for end-of-auction fills
 
-**Mathematical Optimization**: Uses cumulative currency tracking (`cumulativeCurrencyRaisedAtClearingPriceX7`) for direct partial fill calculation:
+**Mathematical Optimization**: Uses cumulative currency tracking (`currencyRaisedAtClearingPriceX128_X7`) for direct partial fill calculation:
 
 ```
-partialFillRate = cumulativeCurrencyRaisedAtClearingPriceX7 * mpsDenominator / (tickDemand * cumulativeMpsDelta)
+partialFillRate = currencyRaisedAtClearingPriceX128_X7 * mpsDenominator / (tickDemand * cumulativeMpsDelta)
 ```
 
 **Implementation**: Enhanced checkpoint architecture with linked-list structure (prev/next pointers) enables efficient traversal. Block numbers are stored as `uint64` for gas optimization while maintaining sufficient range (~584 billion years).

--- a/snapshots/AuctionTest.json
+++ b/snapshots/AuctionTest.json
@@ -1,16 +1,16 @@
 {
-  "checkpoint_advanceToCurrentStep": "163382",
-  "checkpoint_noBids": "147304",
-  "checkpoint_zeroSupply": "121519",
+  "checkpoint_advanceToCurrentStep": "163312",
+  "checkpoint_noBids": "147253",
+  "checkpoint_zeroSupply": "121431",
   "claimTokens": "80599",
   "exitBid": "85410",
-  "exitPartiallyFilledBid": "257099",
+  "exitPartiallyFilledBid": "257495",
   "submitBid": "152369",
   "submitBidWithoutPrevTickPrice": "152402",
   "submitBidWithoutPrevTickPrice_initializeTick_search": "200104",
-  "submitBidWithoutPrevTickPrice_initializeTick_updateCheckpoint": "321674",
-  "submitBid_recordStep_updateCheckpoint": "321641",
-  "submitBid_recordStep_updateCheckpoint_initializeTick": "321641",
-  "submitBid_updateCheckpoint": "299413",
-  "submitBid_withValidationHook": "325807"
+  "submitBidWithoutPrevTickPrice_initializeTick_updateCheckpoint": "321623",
+  "submitBid_recordStep_updateCheckpoint": "321590",
+  "submitBid_recordStep_updateCheckpoint_initializeTick": "321590",
+  "submitBid_updateCheckpoint": "299362",
+  "submitBid_withValidationHook": "325756"
 }

--- a/src/Auction.sol
+++ b/src/Auction.sol
@@ -127,16 +127,17 @@ contract Auction is
         view
         returns (Checkpoint memory)
     {
-        ValueX7 currencyRaisedX7;
+        ValueX7 currencyRaisedX128_X7;
         // If the clearing price is above the floor price, the auction is fully subscribed and the amount of
         // currency which will be raised is deterministic based on the initial supply schedule.
         if (_checkpoint.clearingPrice > FLOOR_PRICE) {
             // The currency raised over `deltaMps` percentage of the auction is simply the total supply
             // over than percentage multiplied by the current clearing price
-            // note that currencyRaised is a ValueX7 because we DO NOT divide by MPS here, 
+            // note that currencyRaised is a ValueX7 because we DO NOT divide by MPS here,
             // and thus the value is 1e7 larger than the actual currency raised
-            currencyRaisedX7 =
-                ValueX7.wrap(TOTAL_SUPPLY * deltaMps).wrapAndFullMulDiv(_checkpoint.clearingPrice, FixedPoint96.Q96);
+            currencyRaisedX128_X7 = ValueX7.wrap(TOTAL_SUPPLY_X128 * deltaMps).wrapAndFullMulDiv(
+                _checkpoint.clearingPrice, FixedPoint96.Q96
+            );
             // There is a special case where the clearing price is at a tick boundary with bids.
             // In this case, we have to explicitly track the supply sold to that price since they are "partially filled"
             // and thus the amount of tokens sold to that price is <= to the collective demand at that price, since bidders at higher prices are prioritized.
@@ -149,22 +150,21 @@ contract Auction is
                 // we upcast it into a X7X7 value to show that it has implicitly been scaled up by 1e7.
                 // currencyRaisedAboveClearingPriceX128_X7 is a ValueX7 because we DO NOT divide by MPS here
                 ValueX7 currencyRaisedAboveClearingPriceX128_X7 =
-                    ValueX7.wrap($sumCurrencyDemandAboveClearingX128.fullMulDiv(deltaMps, FixedPoint128.Q128));
+                    ValueX7.wrap($sumCurrencyDemandAboveClearingX128 * deltaMps);
                 ValueX7 currencyRaisedAtClearingPriceX128_X7 =
-                    currencyRaisedX7.sub(currencyRaisedAboveClearingPriceX128_X7);
+                    currencyRaisedX128_X7.sub(currencyRaisedAboveClearingPriceX128_X7);
                 // Update the cumulative value in the checkpoint which will be reset if the clearing price changes
-                _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7 =
-                    _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7.add(currencyRaisedAtClearingPriceX128_X7);
+                _checkpoint.currencyRaisedAtClearingPriceX128_X7 =
+                    _checkpoint.currencyRaisedAtClearingPriceX128_X7.add(currencyRaisedAtClearingPriceX128_X7);
             }
         }
         // In the case where the auction is not fully subscribed yet, we can only sell tokens equal to the current demand above the clearing price
         else {
             // We are behind schedule as the clearing price is still at the floor price
             // So we can only sell tokens to the current demand above the clearing price
-            currencyRaisedX7 =
-                ValueX7.wrap($sumCurrencyDemandAboveClearingX128.fullMulDiv(deltaMps, FixedPoint128.Q128));
+            currencyRaisedX128_X7 = ValueX7.wrap($sumCurrencyDemandAboveClearingX128 * deltaMps);
         }
-        _checkpoint.currencyRaisedX7 = _checkpoint.currencyRaisedX7.add(currencyRaisedX7);
+        _checkpoint.currencyRaisedX128_X7 = _checkpoint.currencyRaisedX128_X7.add(currencyRaisedX128_X7);
         _checkpoint.cumulativeMps += deltaMps;
         // Calculate the harmonic mean of the mps and price
         _checkpoint.cumulativeMpsPerPrice += CheckpointLib.getMpsPerPrice(deltaMps, _checkpoint.clearingPrice);
@@ -205,13 +205,12 @@ contract Auction is
     {
         /**
          * The new clearing price is simply the ratio of the cumulative currency demand above the clearing price
-         * to the total supply of the auction. It is multiplied by Q96 to return a value in terms of X96 form. 
+         * to the total supply of the auction. It is multiplied by Q96 to return a value in terms of X96 form.
          *
-         * The result of this may be lower than tickLowerPrice. 
+         * The result of this may be lower than tickLowerPrice.
          * That just means that we can't sell at any price above and should sell at tickLowerPrice instead.
          */
-        uint256 clearingPrice =
-            _sumCurrencyDemandAboveClearingX128.fullMulDivUp(FixedPoint96.Q96, TOTAL_SUPPLY.toX128());
+        uint256 clearingPrice = _sumCurrencyDemandAboveClearingX128.fullMulDivUp(FixedPoint96.Q96, TOTAL_SUPPLY_X128);
         if (clearingPrice < _tickLowerPrice) return _tickLowerPrice;
         return clearingPrice;
     }
@@ -287,7 +286,7 @@ contract Auction is
         if (clearingPrice != _checkpoint.clearingPrice) {
             // Set the new clearing price
             _checkpoint.clearingPrice = clearingPrice;
-            _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7 = ValueX7.wrap(0);
+            _checkpoint.currencyRaisedAtClearingPriceX128_X7 = ValueX7.wrap(0);
             emit ClearingPriceUpdated(blockNumber, clearingPrice);
         }
 
@@ -306,7 +305,7 @@ contract Auction is
         _insertCheckpoint(_checkpoint, blockNumber);
 
         emit CheckpointUpdated(
-            blockNumber, _checkpoint.clearingPrice, _checkpoint.currencyRaisedX7, _checkpoint.cumulativeMps
+            blockNumber, _checkpoint.clearingPrice, _checkpoint.currencyRaisedX128_X7, _checkpoint.cumulativeMps
         );
     }
 
@@ -422,10 +421,10 @@ contract Auction is
 
         if (bid.maxPrice <= finalCheckpoint.clearingPrice) revert CannotExitBid();
         /// @dev Bid was fully filled and the auction is now over
-        (uint256 tokensFilled, uint256 currencySpent) =
+        (uint256 tokensFilled, uint256 currencySpentX128) =
             _accountFullyFilledCheckpoints(finalCheckpoint, _getCheckpoint(bid.startBlock), bid);
 
-        _processExit(bidId, bid, tokensFilled, bid.amountX128 - currencySpent);
+        _processExit(bidId, bid, tokensFilled, bid.amountX128 - currencySpentX128);
     }
 
     /// @inheritdoc IAuction
@@ -512,7 +511,7 @@ contract Auction is
         uint256 bidMaxPrice = bid.maxPrice; // place on stack
         if (upperCheckpoint.clearingPrice == bidMaxPrice) {
             (uint256 partialTokensFilled, uint256 partialCurrencySpentX128) = _accountPartiallyFilledCheckpoints(
-                bid, _getTick(bidMaxPrice).currencyDemandX128, upperCheckpoint.cumulativeCurrencyRaisedAtClearingPriceX7
+                bid, _getTick(bidMaxPrice).currencyDemandX128, upperCheckpoint.currencyRaisedAtClearingPriceX128_X7
             );
             tokensFilled += partialTokensFilled;
             currencySpentX128 += partialCurrencySpentX128;
@@ -577,7 +576,7 @@ contract Auction is
         Checkpoint memory finalCheckpoint = _getFinalCheckpoint();
         // Cannot sweep currency if the auction has not graduated, as all of the Currency must be refunded
         if (!_isGraduated(finalCheckpoint)) revert NotGraduated();
-        _sweepCurrency(finalCheckpoint.getCurrencyRaised());
+        _sweepCurrency(finalCheckpoint.currencyRaisedX128_X7.scaleDownToUint256().fromX128());
     }
 
     /// @inheritdoc IAuction

--- a/src/CheckpointStorage.sol
+++ b/src/CheckpointStorage.sol
@@ -40,7 +40,11 @@ abstract contract CheckpointStorage is ICheckpointStorage {
 
     /// @inheritdoc ICheckpointStorage
     function currencyRaised() public view returns (uint256) {
-        return _getCheckpoint($lastCheckpointedBlock).getCurrencyRaised();
+        return _getCheckpoint($lastCheckpointedBlock).currencyRaisedX128_X7.scaleDownToUint256().fromX128();
+    }
+
+    function currencyRaisedX128() public view returns (uint256) {
+        return _getCheckpoint($lastCheckpointedBlock).currencyRaisedX128_X7.scaleDownToUint256();
     }
 
     /// @notice Get a checkpoint from storage
@@ -82,19 +86,19 @@ abstract contract CheckpointStorage is ICheckpointStorage {
     /// @notice Calculate the tokens sold and currency spent for a partially filled bid
     /// @param bid The bid
     /// @param tickDemandX128 The total demand at the tick
-    /// @param cumulativeCurrencyRaisedAtClearingPriceX7 The cumulative supply sold to the clearing price
+    /// @param currencyRaisedAtClearingPriceX128_X7 The cumulative supply sold to the clearing price
     /// @return tokensFilled The tokens sold
     /// @return currencySpentX128 The amount of currency spent in X128.128 form
     function _accountPartiallyFilledCheckpoints(
         Bid memory bid,
         uint256 tickDemandX128,
-        ValueX7 cumulativeCurrencyRaisedAtClearingPriceX7
+        ValueX7 currencyRaisedAtClearingPriceX128_X7
     ) internal pure returns (uint256 tokensFilled, uint256 currencySpentX128) {
         if (tickDemandX128 == 0) return (0, 0);
 
         // TODO(ez): fix comments
         ValueX7 currencySpentX128_X7 = bid.amountX128.scaleUpToX7().fullMulDiv(
-            cumulativeCurrencyRaisedAtClearingPriceX7.mulUint256(FixedPoint128.Q128),
+            currencyRaisedAtClearingPriceX128_X7,
             ValueX7.wrap(tickDemandX128 * bid.mpsRemainingInAuctionAfterSubmission())
         );
         currencySpentX128 = currencySpentX128_X7.scaleDownToUint256();

--- a/src/interfaces/IAuction.sol
+++ b/src/interfaces/IAuction.sol
@@ -89,10 +89,10 @@ interface IAuction is
     /// @notice Emitted when a new checkpoint is created
     /// @param blockNumber The block number of the checkpoint
     /// @param clearingPrice The clearing price of the checkpoint
-    /// @param currencyRaisedX7 The total currency raised
+    /// @param currencyRaisedX128_X7 The total currency raised
     /// @param cumulativeMps The cumulative percentage of total tokens allocated across all previous steps, represented in ten-millionths of the total supply (1e7 = 100%)
     event CheckpointUpdated(
-        uint256 indexed blockNumber, uint256 clearingPrice, ValueX7 currencyRaisedX7, uint24 cumulativeMps
+        uint256 indexed blockNumber, uint256 clearingPrice, ValueX7 currencyRaisedX128_X7, uint24 cumulativeMps
     );
 
     /// @notice Emitted when the clearing price is updated

--- a/src/libraries/CheckpointLib.sol
+++ b/src/libraries/CheckpointLib.sol
@@ -10,8 +10,8 @@ import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 
 struct Checkpoint {
     uint256 clearingPrice; // The X96 price which the auction is currently clearing at
-    ValueX7 currencyRaisedX7; // The actual currency raised (sold for tokens) so far in the auction
-    ValueX7 cumulativeCurrencyRaisedAtClearingPriceX7; // The tokens sold so far to this clearing price
+    ValueX7 currencyRaisedX128_X7; // The actual currency raised (sold for tokens) so far in the auction
+    ValueX7 currencyRaisedAtClearingPriceX128_X7; // The tokens sold so far to this clearing price
     uint256 cumulativeMpsPerPrice; // A running sum of the ratio between mps and price
     uint24 cumulativeMps; // The number of mps sold in the auction so far (via the original supply schedule)
     uint64 prev; // Block number of the previous checkpoint
@@ -40,12 +40,5 @@ library CheckpointLib {
         if (price == 0) return 0;
         // The bitshift cannot overflow because a uint24 shifted left 96 * 2 will always be less than 2^256
         return uint256(mps).fullMulDiv(FixedPoint96.Q96 ** 2, price);
-    }
-
-    /// @notice Return the total currency raised at the given checkpoint
-    /// @param checkpoint the checkpoint
-    /// @return The total currency raised in uint256 form
-    function getCurrencyRaised(Checkpoint memory checkpoint) internal pure returns (uint256) {
-        return checkpoint.currencyRaisedX7.scaleDownToUint256();
     }
 }

--- a/test/Auction.poc.t.sol
+++ b/test/Auction.poc.t.sol
@@ -67,7 +67,7 @@ contract Leftovers is AuctionBaseTest {
         Checkpoint memory cp1 = mockAuction.checkpoint();
         emit log_named_uint('Cp1, block', block.number);
         emit log_named_decimal_uint('Cp1, Price after bid1', cp1.clearingPrice / 1e14, 18);
-        emit log_named_decimal_uint('Cp1, raised', ValueX7.unwrap(cp1.currencyRaisedX7) / 1e14, 18);
+        emit log_named_decimal_uint('Cp1, raised', ValueX7.unwrap(cp1.currencyRaisedX128_X7) / 1e14, 18);
 
         // PERIOD 2: Add second bid at tick30
         if (_withSecondBid) {
@@ -84,7 +84,7 @@ contract Leftovers is AuctionBaseTest {
             vm.roll(block.number + 1);
             emit log_named_uint('Cp2, block', block.number);
             Checkpoint memory cp2 = mockAuction.checkpoint();
-            emit log_named_decimal_uint('Cp2, raised', ValueX7.unwrap(cp2.currencyRaisedX7) / 1e7, 18);
+            emit log_named_decimal_uint('Cp2, raised', ValueX7.unwrap(cp2.currencyRaisedX128_X7) / 1e7, 18);
             emit log_named_decimal_uint('Cp2, Price after second bid', cp2.clearingPrice / 1e14, 18);
             emit log_named_decimal_uint('Cp2, Cumulative MPS', cp2.cumulativeMps, 5);
         }
@@ -92,7 +92,7 @@ contract Leftovers is AuctionBaseTest {
         {
             vm.roll(block.number + 1);
             Checkpoint memory cp3 = mockAuction.checkpoint();
-            emit log_named_decimal_uint('Cp3, raised', ValueX7.unwrap(cp3.currencyRaisedX7) / 1e7, 18);
+            emit log_named_decimal_uint('Cp3, raised', ValueX7.unwrap(cp3.currencyRaisedX128_X7) / 1e7, 18);
             emit log_named_decimal_uint('Cp3, Price after second bid', cp3.clearingPrice / 1e14, 18);
             emit log_named_decimal_uint('Cp3, Cumulative MPS', cp3.cumulativeMps, 5);
         }
@@ -104,7 +104,7 @@ contract Leftovers is AuctionBaseTest {
         emit log_named_uint('Final checkpoint block', block.number);
 
         bool graduated = mockAuction.isGraduated();
-        uint256 raised = ValueX7.unwrap(finalCheckpoint.currencyRaisedX7) / 1e7;
+        uint256 raised = ValueX7.unwrap(finalCheckpoint.currencyRaisedX128_X7) / 1e7;
 
         emit log('==================== FINAL CHECKPOINT ====================');
         emit log_named_decimal_uint('Raised', raised, 18);
@@ -115,7 +115,7 @@ contract Leftovers is AuctionBaseTest {
         emit log_named_decimal_uint('P-30 ', tick30 / 1e14, 18);
         emit log_named_decimal_uint('Cumulative MPS', finalCheckpoint.cumulativeMps, 5);
         emit log_named_string('Graduated', graduated ? 'true' : 'false');
-        emit log_named_decimal_uint('Currency raised', CheckpointLib.getCurrencyRaised(finalCheckpoint), 18);
+        emit log_named_decimal_uint('Currency raised', mockAuction.currencyRaised(), 18);
 
         if (!_sweepEarly) {
             exitAndClaim(_sweepEarly);
@@ -132,7 +132,7 @@ contract Leftovers is AuctionBaseTest {
 
     function exitAndClaim(bool _sweepEarly) public {
         Checkpoint memory finalCheckpoint = mockAuction.checkpoint();
-        uint256 raised = ValueX7.unwrap(finalCheckpoint.currencyRaisedX7) / 1e7;
+        uint256 raised = ValueX7.unwrap(finalCheckpoint.currencyRaisedX128_X7) / 1e7;
 
         {
             emit log('==================== EXITING BIDS ====================');

--- a/test/Auction.steps.t.sol
+++ b/test/Auction.steps.t.sol
@@ -101,7 +101,7 @@ contract AuctionStepDiffTest is AuctionBaseTest {
 
         // Both auctions should have sold the TOTAL_SUPPLY at the same clearing price, and the same cumulative mps
         assertEq(finalCheckpoint1.cumulativeMps, finalCheckpoint2.cumulativeMps);
-        assertEq(finalCheckpoint1.currencyRaisedX7, finalCheckpoint2.currencyRaisedX7);
+        assertEq(finalCheckpoint1.currencyRaisedX128_X7, finalCheckpoint2.currencyRaisedX128_X7);
         assertEq(finalCheckpoint1.clearingPrice, finalCheckpoint2.clearingPrice);
     }
 
@@ -146,11 +146,8 @@ contract AuctionStepDiffTest is AuctionBaseTest {
         // Assert that values in the final checkpoint is the same as the checkpoint after selling 1e7 mps worth of tokens
         assertEq(finalCheckpoint.cumulativeMps, checkpoint.cumulativeMps);
         assertEq(finalCheckpoint.clearingPrice, checkpoint.clearingPrice);
-        assertEq(finalCheckpoint.currencyRaisedX7, checkpoint.currencyRaisedX7);
-        assertEq(
-            finalCheckpoint.cumulativeCurrencyRaisedAtClearingPriceX7,
-            checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7
-        );
+        assertEq(finalCheckpoint.currencyRaisedX128_X7, checkpoint.currencyRaisedX128_X7);
+        assertEq(finalCheckpoint.currencyRaisedAtClearingPriceX128_X7, checkpoint.currencyRaisedAtClearingPriceX128_X7);
         assertEq(finalCheckpoint.cumulativeMpsPerPrice, checkpoint.cumulativeMpsPerPrice);
         // Don't check mps, prev, and next because they will be different
 

--- a/test/Auction.t.sol
+++ b/test/Auction.t.sol
@@ -15,7 +15,6 @@ import {Checkpoint} from '../src/libraries/CheckpointLib.sol';
 import {CheckpointLib} from '../src/libraries/CheckpointLib.sol';
 import {ConstantsLib} from '../src/libraries/ConstantsLib.sol';
 import {Currency, CurrencyLibrary} from '../src/libraries/CurrencyLibrary.sol';
-
 import {FixedPoint128} from '../src/libraries/FixedPoint128.sol';
 import {FixedPoint96} from '../src/libraries/FixedPoint96.sol';
 import {ValueX7, ValueX7Lib} from '../src/libraries/ValueX7Lib.sol';
@@ -122,7 +121,7 @@ contract AuctionTest is AuctionBaseTest {
 
         vm.roll(block.number + 1);
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
-        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
         );
         vm.expectEmit(true, true, true, true);
@@ -147,7 +146,7 @@ contract AuctionTest is AuctionBaseTest {
 
         vm.roll(block.number + 1);
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
-        ValueX7 expectedCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
         );
         vm.expectEmit(true, true, true, true);
@@ -187,7 +186,7 @@ contract AuctionTest is AuctionBaseTest {
 
         vm.roll(block.number + 1);
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
-        ValueX7 expectedCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
         );
         // New block, expect the clearing price to be updated and one block's worth of mps to be sold
@@ -253,7 +252,7 @@ contract AuctionTest is AuctionBaseTest {
         vm.roll(auction.startBlock() + 101);
 
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
-        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
         );
         // Now the auction should start clearing
@@ -309,7 +308,7 @@ contract AuctionTest is AuctionBaseTest {
 
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
         ValueX7 expectedTotalCurrencyRaised =
-            ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv($maxPrice * expectedCumulativeMps, FixedPoint96.Q96);
+            ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv($maxPrice * expectedCumulativeMps, FixedPoint96.Q96);
         // Now the auction should start clearing
         vm.expectEmit(true, true, true, true);
         emit IAuction.CheckpointUpdated(block.number, $maxPrice, expectedTotalCurrencyRaised, expectedCumulativeMps);
@@ -504,7 +503,7 @@ contract AuctionTest is AuctionBaseTest {
             bytes('')
         );
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
-        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(3) * expectedCumulativeMps, FixedPoint96.Q96
         );
 
@@ -560,7 +559,7 @@ contract AuctionTest is AuctionBaseTest {
         vm.expectEmit(true, true, true, true);
         uint24 expectedCumulativeMps = 100e3; // 100e3 mps * 1 block
         ValueX7 expectedTotalCurrencyRaised =
-            ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv($maxPrice * expectedCumulativeMps, FixedPoint96.Q96);
+            ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv($maxPrice * expectedCumulativeMps, FixedPoint96.Q96);
         emit IAuction.CheckpointUpdated(block.number, $maxPrice, expectedTotalCurrencyRaised, expectedCumulativeMps);
         auction.checkpoint();
 
@@ -1140,7 +1139,7 @@ contract AuctionTest is AuctionBaseTest {
         // Expect the final checkpoint to be made
         vm.expectEmit(true, true, true, true);
         uint24 expectedCumulativeMps = ConstantsLib.MPS;
-        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDiv(
+        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDiv(
             tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
         );
         emit IAuction.CheckpointUpdated(
@@ -1314,14 +1313,15 @@ contract AuctionTest is AuctionBaseTest {
         emit IAuction.CheckpointUpdated(
             block.number,
             tickNumberToPriceX96(2),
-            ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDivUp(tickNumberToPriceX96(2) * ConstantsLib.MPS, FixedPoint96.Q96),
+            ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDivUp(
+                tickNumberToPriceX96(2) * ConstantsLib.MPS, FixedPoint96.Q96
+            ),
             ConstantsLib.MPS
         );
         mockAuction.checkpoint();
     }
 
     function test_advanceToCurrentStep_blockNumberIsEndOfStep() public {
-        // 10 blocks of 0 mps, then 100 blocks of 100e3 mps (1%) each
         uint64 startBlock = uint64(block.number);
         uint64 endBlock = startBlock + 40;
         params = params.withAuctionStepsData(AuctionStepsBuilder.init().addStep(100e3, 10).addStep(300e3, 30))
@@ -1397,14 +1397,17 @@ contract AuctionTest is AuctionBaseTest {
 
         // Roll to end of the auction
         vm.roll(endBlock);
+        // Since there is no rollover and we skipped the first 10% of the auction, we expect to sell 90% of the total supply
         vm.expectEmit(true, true, true, true);
-        // Expect that we sold the total supply at price of 2
-        uint24 expectedCumulativeMps = ConstantsLib.MPS;
-        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY).wrapAndFullMulDivUp(
-            tickNumberToPriceX96(2) * expectedCumulativeMps, FixedPoint96.Q96
+        ValueX7 expectedTotalCurrencyRaised = ValueX7.wrap(TOTAL_SUPPLY_X128).wrapAndFullMulDivUp(
+            tickNumberToPriceX96(2) * (ConstantsLib.MPS - 100e3 * 10), FixedPoint96.Q96
         );
         emit IAuction.CheckpointUpdated(
-            startBlock + 40, tickNumberToPriceX96(2), expectedTotalCurrencyRaised, expectedCumulativeMps
+            // Yet the `cumulativeMps` should still be 100%
+            startBlock + 40,
+            tickNumberToPriceX96(2),
+            expectedTotalCurrencyRaised,
+            ConstantsLib.MPS
         );
         mockAuction.checkpoint();
     }
@@ -1949,8 +1952,8 @@ contract AuctionTest is AuctionBaseTest {
         auction.submitBid{value: inputAmount}($maxPrice, inputAmount, alice, tickNumberToPriceX96(1), bytes(''));
 
         vm.roll(auction.endBlock());
-        Checkpoint memory checkpoint = auction.checkpoint();
-        uint256 expectedCurrencyRaised = checkpoint.currencyRaisedX7.scaleDownToUint256();
+        auction.checkpoint();
+        uint256 expectedCurrencyRaised = auction.currencyRaised();
 
         vm.prank(fundsRecipient);
         vm.expectEmit(true, true, true, true);

--- a/test/CheckpointStorage.t.sol
+++ b/test/CheckpointStorage.t.sol
@@ -78,7 +78,7 @@ contract CheckpointStorageTest is Assertions, Test {
 
         // The checkpoint should be empty (all fields default to 0)
         assertEq(checkpoint.clearingPrice, 0);
-        assertEq(checkpoint.currencyRaisedX7, ValueX7.wrap(0));
+        assertEq(checkpoint.currencyRaisedX128_X7, ValueX7.wrap(0));
         assertEq(checkpoint.cumulativeMps, 0);
 
         checkpoint.clearingPrice = 1;
@@ -233,7 +233,7 @@ contract CheckpointStorageTest is Assertions, Test {
 
         Checkpoint memory _checkpoint = mockCheckpointStorage.latestCheckpoint();
         (uint256 tokensFilled, uint256 currencySpent) = mockCheckpointStorage.accountPartiallyFilledCheckpoints(
-            bid, 1e18, _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7
+            bid, 1e18, _checkpoint.currencyRaisedAtClearingPriceX128_X7
         );
         assertEq(tokensFilled, 0);
         assertEq(currencySpent, 0);
@@ -246,12 +246,12 @@ contract CheckpointStorageTest is Assertions, Test {
         vm.assume(bid.maxPrice > 0);
 
         Checkpoint memory _checkpoint = mockCheckpointStorage.latestCheckpoint();
-        _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7 = ValueX7.wrap(1e18);
+        _checkpoint.currencyRaisedAtClearingPriceX128_X7 = ValueX7.wrap(1e18);
 
         (uint256 tokensFilled, uint256 currencySpent) = mockCheckpointStorage.accountPartiallyFilledCheckpoints(
             bid,
             0, // tick demand
-            _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7
+            _checkpoint.currencyRaisedAtClearingPriceX128_X7
         );
         assertEq(tokensFilled, 0);
         assertEq(currencySpent, 0);

--- a/test/unit/Auction.iterateOverTicks.t.sol
+++ b/test/unit/Auction.iterateOverTicks.t.sol
@@ -44,9 +44,9 @@ contract AuctionIterateOverTicksTest is AuctionUnitTest {
     ) public setUpMockAuctionFuzz(_deploymentParams) setUpBidsFuzz(_bids) givenValidCheckpoint(_checkpoint) {
         // Assume there are still tokens to sell in the auction
         vm.assume(_checkpoint.remainingMpsInAuction() > 0);
-        _checkpoint.currencyRaisedX7 = ValueX7.wrap(
+        _checkpoint.currencyRaisedX128_X7 = ValueX7.wrap(
             _bound(
-                ValueX7.unwrap(_checkpoint.currencyRaisedX7),
+                ValueX7.unwrap(_checkpoint.currencyRaisedX128_X7),
                 0,
                 // Checkpoint starts off with not enough currency raised to fully subscribe at the floor price
                 mockAuction.totalSupply().fullMulDivUp(mockAuction.floorPrice(), FixedPoint96.Q96) - 1

--- a/test/utils/Assertions.sol
+++ b/test/utils/Assertions.sol
@@ -12,12 +12,12 @@ abstract contract Assertions is StdAssertions {
         return keccak256(
             abi.encode(
                 _checkpoint.clearingPrice,
-                _checkpoint.currencyRaisedX7,
+                _checkpoint.currencyRaisedX128_X7,
                 _checkpoint.cumulativeMps,
                 _checkpoint.prev,
                 _checkpoint.next,
                 _checkpoint.cumulativeMpsPerPrice,
-                _checkpoint.cumulativeCurrencyRaisedAtClearingPriceX7
+                _checkpoint.currencyRaisedAtClearingPriceX128_X7
             )
         );
     }

--- a/test/utils/MockCheckpointStorage.sol
+++ b/test/utils/MockCheckpointStorage.sol
@@ -26,9 +26,9 @@ contract MockCheckpointStorage is CheckpointStorage {
     function accountPartiallyFilledCheckpoints(
         Bid memory bid,
         uint256 tickDemandX128,
-        ValueX7 cumulativeCurrencyRaisedAtClearingPriceX7
+        ValueX7 currencyRaisedAtClearingPriceX128_X7
     ) public pure returns (uint256 tokensFilled, uint256 currencySpent) {
-        return _accountPartiallyFilledCheckpoints(bid, tickDemandX128, cumulativeCurrencyRaisedAtClearingPriceX7);
+        return _accountPartiallyFilledCheckpoints(bid, tickDemandX128, currencyRaisedAtClearingPriceX128_X7);
     }
 
     function calculateFill(Bid memory bid, uint256 cumulativeMpsPerPriceDelta, uint24 cumulativeMpsDelta)


### PR DESCRIPTION
Without also tracking currencyRaised in 128x128 representation, we would lose precision when clearing price was sufficiently low