### PR TITLE
feat(checkpoints): enforce monotonic checkpoint insertion and add coverage

### DIFF
--- a/snapshots/AuctionTest.json
+++ b/snapshots/AuctionTest.json
@@ -1,16 +1,16 @@
 {
-  "checkpoint_advanceToCurrentStep": "161441",
-  "checkpoint_noBids": "144691",
-  "checkpoint_zeroSupply": "116960",
+  "checkpoint_advanceToCurrentStep": "161505",
+  "checkpoint_noBids": "144755",
+  "checkpoint_zeroSupply": "117074",
   "claimTokens": "79459",
   "exitBid": "84623",
-  "exitPartiallyFilledBid": "235339",
+  "exitPartiallyFilledBid": "235453",
   "submitBid": "150117",
   "submitBidWithoutPrevTickPrice": "150149",
   "submitBidWithoutPrevTickPrice_initializeTick_search": "198188",
-  "submitBidWithoutPrevTickPrice_initializeTick_updateCheckpoint": "319404",
-  "submitBid_recordStep_updateCheckpoint": "319372",
-  "submitBid_recordStep_updateCheckpoint_initializeTick": "319372",
-  "submitBid_updateCheckpoint": "282221",
-  "submitBid_withValidationHook": "323537"
+  "submitBidWithoutPrevTickPrice_initializeTick_updateCheckpoint": "319468",
+  "submitBid_recordStep_updateCheckpoint": "319436",
+  "submitBid_recordStep_updateCheckpoint_initializeTick": "319436",
+  "submitBid_updateCheckpoint": "282335",
+  "submitBid_withValidationHook": "323601"
 }

--- a/src/CheckpointStorage.sol
+++ b/src/CheckpointStorage.sol
@@ -45,6 +45,8 @@ abstract contract CheckpointStorage is ICheckpointStorage {
     /// @dev This function updates the prev and next pointers of the latest checkpoint and the new checkpoint
     function _insertCheckpoint(Checkpoint memory checkpoint, uint64 blockNumber) internal {
         uint64 _lastCheckpointedBlock = $lastCheckpointedBlock;
+        // Enforce strictly increasing checkpoint block numbers after the first insert
+        if (_lastCheckpointedBlock != 0 && blockNumber <= _lastCheckpointedBlock) revert CheckpointBlockNotIncreasing();
         if (_lastCheckpointedBlock != 0) $_checkpoints[_lastCheckpointedBlock].next = blockNumber;
         checkpoint.prev = _lastCheckpointedBlock;
         checkpoint.next = MAX_BLOCK_NUMBER;

--- a/src/interfaces/ICheckpointStorage.sol
+++ b/src/interfaces/ICheckpointStorage.sol
@@ -5,6 +5,9 @@ import {Checkpoint} from '../libraries/CheckpointLib.sol';
 
 /// @notice Interface for checkpoint storage operations
 interface ICheckpointStorage {
+    /// @notice Revert when attempting to insert a checkpoint at a block number not strictly greater than the last one
+    error CheckpointBlockNotIncreasing();
+
     /// @notice Get the latest checkpoint at the last checkpointed block
     /// @return The latest checkpoint
     function latestCheckpoint() external view returns (Checkpoint memory);

--- a/test/CheckpointStorage.t.sol
+++ b/test/CheckpointStorage.t.sol
@@ -6,6 +6,7 @@ import {AuctionStepLib} from '../src/libraries/AuctionStepLib.sol';
 import {Bid, BidLib} from '../src/libraries/BidLib.sol';
 import {Checkpoint} from '../src/libraries/CheckpointLib.sol';
 import {CheckpointLib} from '../src/libraries/CheckpointLib.sol';
+import {ICheckpointStorage} from '../src/interfaces/ICheckpointStorage.sol';
 import {ConstantsLib} from '../src/libraries/ConstantsLib.sol';
 import {FixedPoint128} from '../src/libraries/FixedPoint128.sol';
 import {FixedPoint96} from '../src/libraries/FixedPoint96.sol';
@@ -32,6 +33,20 @@ contract CheckpointStorageTest is Assertions, Test {
 
     function setUp() public {
         mockCheckpointStorage = new MockCheckpointStorage();
+    }
+
+    function test_insertCheckpoint_equalBlock_reverts() public {
+        Checkpoint memory _checkpoint;
+        mockCheckpointStorage.insertCheckpoint(_checkpoint, 100);
+        vm.expectRevert(ICheckpointStorage.CheckpointBlockNotIncreasing.selector);
+        mockCheckpointStorage.insertCheckpoint(_checkpoint, 100);
+    }
+
+    function test_insertCheckpoint_lowerBlock_reverts() public {
+        Checkpoint memory _checkpoint;
+        mockCheckpointStorage.insertCheckpoint(_checkpoint, 100);
+        vm.expectRevert(ICheckpointStorage.CheckpointBlockNotIncreasing.selector);
+        mockCheckpointStorage.insertCheckpoint(_checkpoint, 99);
     }
 
     function test_insertCheckpoint_firstCheckpoint_succeeds() public {

--- a/test/btt/checkpointStorage/insertCheckpoint.t.sol
+++ b/test/btt/checkpointStorage/insertCheckpoint.t.sol
@@ -63,6 +63,10 @@ contract InsertCheckpointTest is BttBase {
         // - It is possible for the "next" to be itself
         // - The $lastCheckpointedBlock might not be the highest block number check pointed
 
+        // Enforce monotonicity constraints introduced by CheckpointStorage
+        vm.assume(_blockNumber > 0);
+        vm.assume(_blockNumber2 > _blockNumber);
+
         mockCheckpointStorage.insertCheckpoint(_checkpoint, _blockNumber);
 
         vm.record();


### PR DESCRIPTION
This change enforces strictly increasing checkpoint block numbers to address an ABDK audit finding. This hardens storage against accidental overwrite or out-of-order links; current paths were already _implicitly_ monotonic, this change explicitly enforces that invariant. Gas impact is negligible; bytecode grows slightly due to the new error path.

- Enforce strictly increasing checkpoint block numbers to prevent overwrites and out-of-order linked-list entries
- Add `ICheckpointStorage.CheckpointBlockNotIncreasing` error selector
- Unit tests assert revert on equal/lower block checkpoint insertion
- Auction E2E tests assert same-block checkpoint is a no-op; revert via MockAuction on non-increasing inserts
- BTT tests updated to align fuzz assumptions with monotonicity