### PR TITLE
chore: rename `IAuctionFactory.InvalidAmount` to `IAuctionFactory.InvalidTokenAmount`

### DIFF
--- a/src/AuctionFactory.sol
+++ b/src/AuctionFactory.sol
@@ -18,7 +18,7 @@ contract AuctionFactory is IAuctionFactory {
         override(IDistributionStrategy)
         returns (IDistributionContract distributionContract)
     {
-        if (amount > type(uint128).max) revert InvalidAmount(amount);
+        if (amount > type(uint128).max) revert InvalidTokenAmount(amount);
 
         AuctionParameters memory parameters = abi.decode(configData, (AuctionParameters));
         // If the tokensRecipient is address(1), set it to the msg.sender
@@ -40,7 +40,7 @@ contract AuctionFactory is IAuctionFactory {
         override(IAuctionFactory)
         returns (address)
     {
-        if (amount > type(uint128).max) revert InvalidAmount(amount);
+        if (amount > type(uint128).max) revert InvalidTokenAmount(amount);
         AuctionParameters memory parameters = abi.decode(configData, (AuctionParameters));
         // If the tokensRecipient is address(1), set it to the msg.sender
         if (parameters.tokensRecipient == ActionConstants.MSG_SENDER) parameters.tokensRecipient = sender;

--- a/src/interfaces/IAuctionFactory.sol
+++ b/src/interfaces/IAuctionFactory.sol
@@ -6,7 +6,7 @@ import {IDistributionStrategy} from './external/IDistributionStrategy.sol';
 /// @title IAuctionFactory
 interface IAuctionFactory is IDistributionStrategy {
     /// @notice Error thrown when the amount is invalid
-    error InvalidAmount(uint256 amount);
+    error InvalidTokenAmount(uint256 amount);
 
     /// @notice Emitted when an auction is created
     /// @param auction The address of the auction contract

--- a/test/btt/auctionFactory/initializeDistribution.t.sol
+++ b/test/btt/auctionFactory/initializeDistribution.t.sol
@@ -20,13 +20,13 @@ contract InitializeDistributionTest is BttBase {
         external
         setupAuctionConstructorParams(_params)
     {
-        // it reverts with {InvalidAmount}
+        // it reverts with {InvalidTokenAmount}
         _amount = uint256(bound(_amount, uint256(type(uint128).max) + 1, type(uint256).max));
 
-        vm.expectRevert(abi.encodeWithSelector(IAuctionFactory.InvalidAmount.selector, _amount));
+        vm.expectRevert(abi.encodeWithSelector(IAuctionFactory.InvalidTokenAmount.selector, _amount));
         factory.initializeDistribution(address(token), _amount, abi.encode(params), bytes32(0));
 
-        vm.expectRevert(abi.encodeWithSelector(IAuctionFactory.InvalidAmount.selector, _amount));
+        vm.expectRevert(abi.encodeWithSelector(IAuctionFactory.InvalidTokenAmount.selector, _amount));
         factory.getAuctionAddress(address(token), _amount, abi.encode(params), bytes32(0), address(0));
     }
 

--- a/test/btt/auctionFactory/initializeDistribution.tree
+++ b/test/btt/auctionFactory/initializeDistribution.tree
@@ -1,6 +1,6 @@
 InitializeDistributionTest
 ├── when amount GT uint128 max
-│   └── it reverts with {InvalidAmount}
+│   └── it reverts with {InvalidTokenAmount}
 └── when amount LE uint128 max
     ├── when tokensRecipient EQ ActionConstants MSG_SENDER
     │   ├── when fundsRecipient EQ ActionConstants MSG_SENDER


### PR DESCRIPTION
To reduce confusion, rename