### PR TITLE
feat: only recipient can sweep

### DIFF
--- a/snapshots/AuctionTest.json
+++ b/snapshots/AuctionTest.json
@@ -1,5 +1,5 @@
 {
-  "Auction bytecode size": "18420",
+  "Auction bytecode size": "18766",
   "checkpoint_advanceToCurrentStep": "179349",
   "checkpoint_noBids": "165321",
   "checkpoint_zeroSupply": "119208",

--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -686,10 +686,10 @@ contract ContinuousClearingAuction is
 
     /// @inheritdoc IContinuousClearingAuction
     function sweepCurrency() external onlyAfterAuctionIsOver ensureEndBlockIsCheckpointed {
-        // Cannot sweep if already swept
-        if (sweepCurrencyBlock != 0) revert CannotSweepCurrency();
         // Only recipient can sweep
         if (msg.sender != FUNDS_RECIPIENT) revert NotAuthorized(FUNDS_RECIPIENT, msg.sender);
+        // Cannot sweep if already swept
+        if (sweepCurrencyBlock != 0) revert CannotSweepCurrency();
         // Cannot sweep currency if the auction has not graduated, as all of the Currency must be refunded
         if (!_isGraduated()) revert NotGraduated();
         _sweepCurrency(_getBlockNumberish(), _currencyRaised());
@@ -697,9 +697,10 @@ contract ContinuousClearingAuction is
 
     /// @inheritdoc IContinuousClearingAuction
     function sweepUnsoldTokens() external onlyAfterAuctionIsOver ensureEndBlockIsCheckpointed {
-        if (sweepUnsoldTokensBlock != 0) revert CannotSweepTokens();
         // Only recipient can sweep
         if (msg.sender != TOKENS_RECIPIENT) revert NotAuthorized(TOKENS_RECIPIENT, msg.sender);
+        // Cannot sweep if already swept
+        if (sweepUnsoldTokensBlock != 0) revert CannotSweepTokens();
         uint256 unsoldTokens;
         if (_isGraduated()) {
             uint256 totalSupplyQ96 = uint256(TOTAL_SUPPLY) << FixedPoint96.RESOLUTION;

--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -688,6 +688,8 @@ contract ContinuousClearingAuction is
     function sweepCurrency() external onlyAfterAuctionIsOver ensureEndBlockIsCheckpointed {
         // Cannot sweep if already swept
         if (sweepCurrencyBlock != 0) revert CannotSweepCurrency();
+        // Only recipient can sweep
+        if (msg.sender != FUNDS_RECIPIENT) revert NotAuthorized(FUNDS_RECIPIENT, msg.sender);
         // Cannot sweep currency if the auction has not graduated, as all of the Currency must be refunded
         if (!_isGraduated()) revert NotGraduated();
         _sweepCurrency(_getBlockNumberish(), _currencyRaised());
@@ -696,6 +698,8 @@ contract ContinuousClearingAuction is
     /// @inheritdoc IContinuousClearingAuction
     function sweepUnsoldTokens() external onlyAfterAuctionIsOver ensureEndBlockIsCheckpointed {
         if (sweepUnsoldTokensBlock != 0) revert CannotSweepTokens();
+        // Only recipient can sweep
+        if (msg.sender != TOKENS_RECIPIENT) revert NotAuthorized(TOKENS_RECIPIENT, msg.sender);
         uint256 unsoldTokens;
         if (_isGraduated()) {
             uint256 totalSupplyQ96 = uint256(TOTAL_SUPPLY) << FixedPoint96.RESOLUTION;

--- a/src/interfaces/IContinuousClearingAuction.sol
+++ b/src/interfaces/IContinuousClearingAuction.sol
@@ -39,7 +39,8 @@ interface IContinuousClearingAuction is
 {
     /// @notice Error thrown when the amount received is invalid
     error InvalidTokenAmountReceived();
-
+    /// @notice Error thrown when an unauthorized caller tries to access restricted functions
+    error NotAuthorized(address authorized, address caller);
     /// @notice Error thrown when an invalid value is deposited
     error InvalidAmount();
     /// @notice Error thrown when the bid owner is the zero address

--- a/test/Auction.graduation.t.sol
+++ b/test/Auction.graduation.t.sol
@@ -461,6 +461,7 @@ contract AuctionGraduationTest is AuctionBaseTest {
         // Should sweep ALL tokens since auction didn't graduate
         vm.expectEmit(true, true, true, true);
         emit ITokenCurrencyStorage.TokensSwept(tokensRecipient, $deploymentParams.totalSupply);
+        vm.prank(tokensRecipient);
         auction.sweepUnsoldTokens();
 
         // Verify all tokens were transferred

--- a/test/Auction.invariant.t.sol
+++ b/test/Auction.invariant.t.sol
@@ -579,6 +579,7 @@ contract AuctionInvariantTest is AuctionUnitTest {
         uint256 expectedCurrencyRaised = mockAuction.currencyRaised();
 
         // We can always sweep unsold tokens regardless of graduation status
+        vm.prank(mockAuction.tokensRecipient());
         mockAuction.sweepUnsoldTokens();
 
         if (mockAuction.isGraduated()) {
@@ -591,6 +592,7 @@ contract AuctionInvariantTest is AuctionUnitTest {
             // Sweep the currency
             vm.expectEmit(true, true, true, true);
             emit ITokenCurrencyStorage.CurrencySwept(mockAuction.fundsRecipient(), expectedCurrencyRaised);
+            vm.prank(mockAuction.fundsRecipient());
             mockAuction.sweepCurrency();
             // Assert that the funds recipient received the currency
             assertEq(
@@ -600,6 +602,7 @@ contract AuctionInvariantTest is AuctionUnitTest {
             );
         } else {
             emit log_string('==================== NOT GRADUATED AUCTION ====================');
+            vm.prank(mockAuction.fundsRecipient());
             vm.expectRevert(ITokenCurrencyStorage.NotGraduated.selector);
             mockAuction.sweepCurrency();
             // At this point we know all bids have been exited so auction balance should be zero

--- a/test/Auction.steps.t.sol
+++ b/test/Auction.steps.t.sol
@@ -164,7 +164,9 @@ contract AuctionStepDiffTest is AuctionBaseTest {
         newAuction.claimTokens(bidId);
         assertEq(token.balanceOf(address(alice)), _totalSupply);
 
+        vm.prank(newAuction.fundsRecipient());
         newAuction.sweepCurrency();
+        vm.prank(newAuction.tokensRecipient());
         newAuction.sweepUnsoldTokens();
     }
 }

--- a/test/Auction.t.sol
+++ b/test/Auction.t.sol
@@ -552,6 +552,7 @@ contract AuctionTest is AuctionBaseTest {
         // Auction fully subscribed so no tokens are left
         vm.expectEmit(true, true, true, true);
         emit ITokenCurrencyStorage.TokensSwept(auction.tokensRecipient(), 0);
+        vm.prank(auction.tokensRecipient());
         auction.sweepUnsoldTokens();
     }
 
@@ -863,6 +864,7 @@ contract AuctionTest is AuctionBaseTest {
         // All tokens were sold
         vm.expectEmit(true, true, true, true);
         emit ITokenCurrencyStorage.TokensSwept(auction.tokensRecipient(), 0);
+        vm.prank(auction.tokensRecipient());
         auction.sweepUnsoldTokens();
     }
 
@@ -993,10 +995,12 @@ contract AuctionTest is AuctionBaseTest {
         // Expect all tokens were swept
         vm.expectEmit(true, true, true, true);
         emit ITokenCurrencyStorage.TokensSwept(newAuction.tokensRecipient(), TOTAL_SUPPLY);
+        vm.prank(newAuction.tokensRecipient());
         newAuction.sweepUnsoldTokens();
         assertEq(token.balanceOf(newAuction.tokensRecipient()), TOTAL_SUPPLY);
 
         // Expect no currency was swept
+        vm.prank(newAuction.fundsRecipient());
         vm.expectRevert(ITokenCurrencyStorage.NotGraduated.selector);
         newAuction.sweepCurrency();
         assertEq(address(newAuction).balance, 0);
@@ -2055,6 +2059,7 @@ contract AuctionTest is AuctionBaseTest {
 
     function test_sweepUnsoldTokens_beforeAuctionEnds_reverts() public {
         vm.roll(auction.endBlock() - 1);
+        vm.prank(auction.tokensRecipient());
         vm.expectRevert(IStepStorage.AuctionIsNotOver.selector);
         auction.sweepUnsoldTokens();
     }
@@ -2089,10 +2094,47 @@ contract AuctionTest is AuctionBaseTest {
         vm.roll(auction.endBlock());
 
         // First sweep should succeed
+        vm.prank(auction.tokensRecipient());
         auction.sweepUnsoldTokens();
 
         // Second sweep should fail
+        vm.prank(auction.tokensRecipient());
         vm.expectRevert(ITokenCurrencyStorage.CannotSweepTokens.selector);
+        auction.sweepUnsoldTokens();
+    }
+
+    // Access control tests for sweep functions
+
+    function test_sweepCurrency_notRecipient_reverts() public {
+        // Submit a bid to ensure auction graduates
+        auction.submitBid{value: inputAmountForTokens(TOTAL_SUPPLY, tickNumberToPriceX96(2))}(
+            tickNumberToPriceX96(2),
+            inputAmountForTokens(TOTAL_SUPPLY, tickNumberToPriceX96(2)),
+            alice,
+            tickNumberToPriceX96(1),
+            bytes('')
+        );
+
+        vm.roll(auction.endBlock());
+
+        // Non-recipient cannot sweep (address(this) is the caller)
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IContinuousClearingAuction.NotAuthorized.selector, auction.fundsRecipient(), address(this)
+            )
+        );
+        auction.sweepCurrency();
+    }
+
+    function test_sweepUnsoldTokens_notRecipient_reverts() public {
+        vm.roll(auction.endBlock());
+
+        // Non-recipient cannot sweep (address(this) is the caller)
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IContinuousClearingAuction.NotAuthorized.selector, auction.tokensRecipient(), address(this)
+            )
+        );
         auction.sweepUnsoldTokens();
     }
 

--- a/test/Auction.t.sol
+++ b/test/Auction.t.sol
@@ -2103,41 +2103,6 @@ contract AuctionTest is AuctionBaseTest {
         auction.sweepUnsoldTokens();
     }
 
-    // Access control tests for sweep functions
-
-    function test_sweepCurrency_notRecipient_reverts() public {
-        // Submit a bid to ensure auction graduates
-        auction.submitBid{value: inputAmountForTokens(TOTAL_SUPPLY, tickNumberToPriceX96(2))}(
-            tickNumberToPriceX96(2),
-            inputAmountForTokens(TOTAL_SUPPLY, tickNumberToPriceX96(2)),
-            alice,
-            tickNumberToPriceX96(1),
-            bytes('')
-        );
-
-        vm.roll(auction.endBlock());
-
-        // Non-recipient cannot sweep (address(this) is the caller)
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IContinuousClearingAuction.NotAuthorized.selector, auction.fundsRecipient(), address(this)
-            )
-        );
-        auction.sweepCurrency();
-    }
-
-    function test_sweepUnsoldTokens_notRecipient_reverts() public {
-        vm.roll(auction.endBlock());
-
-        // Non-recipient cannot sweep (address(this) is the caller)
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IContinuousClearingAuction.NotAuthorized.selector, auction.tokensRecipient(), address(this)
-            )
-        );
-        auction.sweepUnsoldTokens();
-    }
-
     // Test that all of the state getters for constants / immutable variables are correct
     function test_constructor_immutable_getters() public {
         assertEq(auction.currency(), ETH_SENTINEL);

--- a/test/btt/auction/SweepUnsoldTokens.t.sol
+++ b/test/btt/auction/SweepUnsoldTokens.t.sol
@@ -24,6 +24,8 @@ contract SweepUnsoldTokensTest is BttBase {
         uint256 blockNumber = bound(_blockNumber, 0, mParams.parameters.endBlock - 1);
 
         vm.roll(blockNumber);
+
+        vm.prank(mParams.parameters.tokensRecipient);
         vm.expectRevert(IStepStorage.AuctionIsNotOver.selector);
         auction.sweepUnsoldTokens();
     }
@@ -51,8 +53,10 @@ contract SweepUnsoldTokensTest is BttBase {
         auction.onTokensReceived();
 
         vm.roll(blockNumber);
+        vm.prank(mParams.parameters.tokensRecipient);
         auction.sweepUnsoldTokens();
 
+        vm.prank(mParams.parameters.tokensRecipient);
         vm.expectRevert(ITokenCurrencyStorage.CannotSweepTokens.selector);
         auction.sweepUnsoldTokens();
     }
@@ -129,6 +133,7 @@ contract SweepUnsoldTokensTest is BttBase {
             0
         );
         vm.record();
+        vm.prank(mParams.parameters.tokensRecipient);
         auction.sweepUnsoldTokens();
 
         (, bytes32[] memory writes) = vm.accesses(address(auction));
@@ -214,6 +219,7 @@ contract SweepUnsoldTokensTest is BttBase {
         vm.expectEmit(true, true, true, true, address(auction));
         emit ITokenCurrencyStorage.TokensSwept(mParams.parameters.tokensRecipient, mParams.totalSupply);
         vm.record();
+        vm.prank(mParams.parameters.tokensRecipient);
         auction.sweepUnsoldTokens();
 
         if (!isCoverage()) {

--- a/test/btt/auction/SweepUnsoldTokens.t.sol
+++ b/test/btt/auction/SweepUnsoldTokens.t.sol
@@ -242,4 +242,39 @@ contract SweepUnsoldTokensTest is BttBase {
             'tokens not transferred to recipient'
         );
     }
+
+    function test_WhenCallerIsNotTokensRecipient(
+        AuctionFuzzConstructorParams memory _params,
+        uint256 _blockNumber,
+        address _unauthorizedCaller
+    ) external whenAuctionIsOver {
+        // it reverts with {NotAuthorized}
+
+        AuctionFuzzConstructorParams memory mParams = validAuctionConstructorInputs(_params);
+        mParams.parameters.requiredCurrencyRaised = 1;
+        mParams.token = address(new ERC20Mock());
+
+        vm.assume(_unauthorizedCaller != mParams.parameters.tokensRecipient);
+
+        MockContinuousClearingAuction auction =
+            new MockContinuousClearingAuction(mParams.token, mParams.totalSupply, mParams.parameters);
+
+        uint256 blockNumber = bound(_blockNumber, mParams.parameters.endBlock, type(uint64).max);
+
+        ERC20Mock(mParams.token).mint(address(auction), mParams.totalSupply);
+        auction.onTokensReceived();
+
+        vm.roll(blockNumber);
+
+        address unauthorizedCaller = makeAddr('unauthorizedCaller');
+        vm.prank(unauthorizedCaller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IContinuousClearingAuction.NotAuthorized.selector,
+                mParams.parameters.tokensRecipient,
+                unauthorizedCaller
+            )
+        );
+        auction.sweepUnsoldTokens();
+    }
 }

--- a/test/btt/auction/sweepCurrency.t.sol
+++ b/test/btt/auction/sweepCurrency.t.sol
@@ -32,6 +32,7 @@ contract SweepCurrencyTest is BttBase {
 
         vm.roll(_blockNumber);
 
+        vm.prank(mParams.parameters.fundsRecipient);
         vm.expectRevert(IStepStorage.AuctionIsNotOver.selector);
         auction.sweepCurrency();
     }
@@ -55,8 +56,10 @@ contract SweepCurrencyTest is BttBase {
         auction.onTokensReceived();
 
         vm.roll(mParams.parameters.endBlock);
+        vm.prank(mParams.parameters.fundsRecipient);
         auction.sweepCurrency();
 
+        vm.prank(mParams.parameters.fundsRecipient);
         vm.expectRevert(ITokenCurrencyStorage.CannotSweepCurrency.selector);
         auction.sweepCurrency();
     }
@@ -100,6 +103,7 @@ contract SweepCurrencyTest is BttBase {
         vm.roll(mParams.parameters.endBlock);
         auction.exitPartiallyFilledBid(bidId, mParams.parameters.startBlock, 0);
 
+        vm.prank(mParams.parameters.fundsRecipient);
         vm.expectRevert(ITokenCurrencyStorage.NotGraduated.selector);
         auction.sweepCurrency();
     }
@@ -148,6 +152,7 @@ contract SweepCurrencyTest is BttBase {
 
         vm.expectEmit(true, true, true, true);
         emit ITokenCurrencyStorage.CurrencySwept(mParams.parameters.fundsRecipient, expectedCurrencyRaised);
+        vm.prank(mParams.parameters.fundsRecipient);
         auction.sweepCurrency();
 
         assertEq(auction.sweepCurrencyBlock(), block.number);
@@ -177,6 +182,7 @@ contract SweepCurrencyTest is BttBase {
         // No bids
 
         vm.roll(mParams.parameters.endBlock);
+        vm.prank(mParams.parameters.fundsRecipient);
         auction.sweepCurrency();
 
         assertEq(auction.sweepCurrencyBlock(), block.number);

--- a/test/btt/auction/sweepCurrency.t.sol
+++ b/test/btt/auction/sweepCurrency.t.sol
@@ -6,6 +6,7 @@ import {MockContinuousClearingAuction} from '../mocks/MockContinuousClearingAuct
 import {ERC20Mock} from 'openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol';
 import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 import {Checkpoint} from 'src/CheckpointStorage.sol';
+import {IContinuousClearingAuction} from 'src/interfaces/IContinuousClearingAuction.sol';
 import {IStepStorage} from 'src/interfaces/IStepStorage.sol';
 import {ITokenCurrencyStorage} from 'src/interfaces/ITokenCurrencyStorage.sol';
 import {ConstantsLib} from 'src/libraries/ConstantsLib.sol';
@@ -187,5 +188,37 @@ contract SweepCurrencyTest is BttBase {
 
         assertEq(auction.sweepCurrencyBlock(), block.number);
         assertEq(mParams.parameters.fundsRecipient.balance, 0);
+    }
+
+    function test_WhenCallerIsNotFundsRecipient(
+        AuctionFuzzConstructorParams memory _params,
+        address _unauthorizedCaller
+    ) public givenAuctionIsGraduated givenNotPreviouslySwept {
+        // it reverts with {NotAuthorized}
+
+        AuctionFuzzConstructorParams memory mParams = validAuctionConstructorInputs(_params);
+
+        vm.assume(_unauthorizedCaller != mParams.parameters.fundsRecipient);
+
+        mParams.token = address(new ERC20Mock());
+        mParams.parameters.currency = address(0);
+        mParams.parameters.requiredCurrencyRaised = 0;
+        mParams.parameters.fundsRecipient = makeAddr('fundsRecipient');
+        MockContinuousClearingAuction auction =
+            new MockContinuousClearingAuction(mParams.token, mParams.totalSupply, mParams.parameters);
+
+        ERC20Mock(mParams.token).mint(address(auction), mParams.totalSupply);
+        auction.onTokensReceived();
+
+        vm.roll(mParams.parameters.endBlock);
+
+        address unauthorizedCaller = makeAddr('unauthorizedCaller');
+        vm.prank(unauthorizedCaller);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IContinuousClearingAuction.NotAuthorized.selector, mParams.parameters.fundsRecipient, unauthorizedCaller
+            )
+        );
+        auction.sweepCurrency();
     }
 }

--- a/test/utils/AuctionBaseTest.sol
+++ b/test/utils/AuctionBaseTest.sol
@@ -534,7 +534,9 @@ abstract contract AuctionBaseTest is TokenHandler, Assertions, Test {
 
             assertLe(auction.totalCleared(), auction.totalSupply(), 'total cleared must be <= total supply');
 
+            vm.prank(auction.fundsRecipient());
             auction.sweepCurrency();
+            vm.prank(auction.tokensRecipient());
             auction.sweepUnsoldTokens();
             // Validate that the tokens and currency dust left in the auction is within a reasonable amount
             assertApproxEqAbs(
@@ -555,10 +557,12 @@ abstract contract AuctionBaseTest is TokenHandler, Assertions, Test {
             );
             emit log_named_decimal_uint('after sweeping currency balance', address(auction).balance, 18);
         } else {
+            vm.prank(auction.tokensRecipient());
             auction.sweepUnsoldTokens();
             // Assert that all tokens were swept
             assertEq(token.balanceOf(auction.tokensRecipient()), auction.totalSupply());
             // Expect to revert when sweeping currency
+            vm.prank(auction.fundsRecipient());
             vm.expectRevert(ITokenCurrencyStorage.NotGraduated.selector);
             auction.sweepCurrency();
         }


### PR DESCRIPTION
# Pull Request

## Description

Only recipient can call `sweepCurrency()` and `sweepUnsoldTokens()`. 
This allows the recipient to properly account for the incoming funds