### PR TITLE
fix: support rollover math in TickDataLens

### DIFF
--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -5,6 +5,8 @@ import {TickStorage} from '../TickStorage.sol';
 import {IContinuousClearingAuction} from '../interfaces/IContinuousClearingAuction.sol';
 import {Tick} from '../interfaces/ITickStorage.sol';
 import {ConstantsLib} from '../libraries/ConstantsLib.sol';
+import {FixedPoint96} from '../libraries/FixedPoint96.sol';
+import {ValueX7} from '../libraries/ValueX7Lib.sol';
 import {AuctionState} from './AuctionStateLens.sol';
 import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 
@@ -37,6 +39,8 @@ contract TickDataLens {
     {
         uint24 mps = ConstantsLib.MPS;
         uint24 remainingMps = mps - auction.latestCheckpoint().cumulativeMps;
+        uint256 remainingSupplyQ96X7 = ValueX7.unwrap(auction.remainingSupplyQ96X7());
+        uint256 requiredDemandDenominator = FixedPoint96.Q96 * remainingMps;
         // Retrieve the sumCurrencyDemandAboveClearingQ96 from storage
         uint256 sumCurrencyDemandAboveClearingQ96 = auction.sumCurrencyDemandAboveClearingQ96();
         // Get the next active tick price
@@ -62,14 +66,13 @@ contract TickDataLens {
                 // Overwrite the next tick price with the current tick price
                 mstore(offset, next)
 
-                // Calculate and store the requiredCurrencyDemandQ96 using the auction's rollover-aware formula
-                mstore(0x00, 0x5ba38798) // ContinuousClearingAuction.requiredDemandQ96(uint256)
-                mstore(0x20, next)
-                success := staticcall(gas(), auction, 0x1c, 0x24, add(offset, 0x40), 0x20)
-                if iszero(success) {
-                    revert(0x00, 0x00)
+                // Calculate and store the requiredCurrencyDemandQ96 using the auction's rollover-aware formula:
+                // fullMulDivUp(remainingSupplyQ96X7, priceQ96, Q96 * remainingMps)
+                let requiredCurrencyDemandQ96 := 0
+                if remainingMps {
+                    requiredCurrencyDemandQ96 := fullMulDivUp(remainingSupplyQ96X7, next, requiredDemandDenominator)
                 }
-                let requiredCurrencyDemandQ96 := mload(add(offset, 0x40))
+                mstore(add(offset, 0x40), requiredCurrencyDemandQ96)
 
                 // Calculate and store the currencyRequiredQ96:
                 // currencyRequiredQ96 = saturatingSub(required, sum).mulDivUp(remainingMps, MPS)
@@ -128,6 +131,45 @@ contract TickDataLens {
                 result := div(mul(x, y), d)
                 if mulmod(x, y, d) {
                     result := add(result, 1)
+                }
+            }
+
+            /// @dev Equivalent to FixedPointMathLib.fullMulDivUp: returns ceil(x * y / d).
+            function fullMulDivUp(x, y, d) -> result {
+                let denominator := d
+                result := mul(x, y)
+                for {} 1 {} {
+                    if iszero(mul(or(iszero(x), eq(div(result, x), y)), d)) {
+                        let mm := mulmod(x, y, not(0))
+                        let p1 := sub(mm, add(result, lt(mm, result)))
+                        let r := mulmod(x, y, d)
+                        let t := and(d, sub(0, d))
+                        if iszero(gt(d, p1)) {
+                            mstore(0x00, 0xae47f702) // FullMulDivFailed()
+                            revert(0x1c, 0x04)
+                        }
+                        d := div(d, t)
+                        let inv := xor(2, mul(3, d))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        result := mul(
+                            or(mul(sub(p1, gt(r, result)), add(div(sub(0, t), t), 1)), div(sub(result, r), t)),
+                            mul(sub(2, mul(d, inv)), inv)
+                        )
+                        break
+                    }
+                    result := div(result, d)
+                    break
+                }
+                if mulmod(x, y, denominator) {
+                    result := add(result, 1)
+                    if iszero(result) {
+                        mstore(0x00, 0xae47f702) // FullMulDivFailed()
+                        revert(0x1c, 0x04)
+                    }
                 }
             }
 

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.26;
 
 import {IContinuousClearingAuction} from '../interfaces/IContinuousClearingAuction.sol';
-import {Tick} from '../interfaces/ITickStorage.sol';
 import {ConstantsLib} from '../libraries/ConstantsLib.sol';
 import {FixedPoint96} from '../libraries/FixedPoint96.sol';
 import {ValueX7} from '../libraries/ValueX7Lib.sol';
@@ -48,33 +47,56 @@ contract TickDataLens {
             revert();
         }
 
-        ticks = new TickWithData[](MAX_BUFFER_SIZE);
-        uint256 tickPrice = next;
-        uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
-        uint256 count;
-        while (count < ticks.length) {
-            Tick memory tick = auction.ticks(tickPrice);
-            uint256 requiredCurrencyDemandQ96;
-            if (remainingMps > 0) {
-                requiredCurrencyDemandQ96 = remainingSupplyQ96X7.fullMulDivUp(tickPrice, requiredDemandDenominator);
+        assembly {
+            let dataStart := mload(0x40)
+            let dataOffset := dataStart
+
+            let idx := 0
+            for {} lt(idx, MAX_BUFFER_SIZE) { idx := add(idx, 1) } {
+                mstore(0x00, 0x534cb30d) // ContinuousClearingAuction.ticks(uint256)
+                mstore(0x20, next)
+
+                let success := staticcall(gas(), auction, 0x1c, 0x24, dataOffset, 0x40)
+                if iszero(success) {
+                    revert(0x00, 0x00)
+                }
+
+                let nextTick := mload(dataOffset)
+                mstore(dataOffset, next)
+                mstore(add(dataOffset, 0x40), 0)
+                mstore(add(dataOffset, 0x60), 0)
+
+                next := nextTick
+                dataOffset := add(dataOffset, 0x80)
+
+                if eq(nextTick, not(0)) {
+                    idx := add(idx, 1)
+                    break
+                }
             }
-            ticks[count] = TickWithData({
-                priceQ96: tickPrice,
-                currencyDemandQ96: tick.currencyDemandQ96,
-                requiredCurrencyDemandQ96: requiredCurrencyDemandQ96,
-                currencyRequiredQ96: requiredCurrencyDemandQ96.saturatingSub(runningDemand)
-                    .fullMulDivUp(remainingMps, mps)
-            });
-            runningDemand -= tick.currencyDemandQ96;
-            tickPrice = tick.next;
-            count++;
-            if (tickPrice == type(uint256).max) {
-                break;
+
+            ticks := dataOffset
+            mstore(ticks, idx)
+
+            let pointerOffset := ticks
+            for { let i := 0 } lt(i, idx) { i := add(i, 1) } {
+                pointerOffset := add(pointerOffset, 0x20)
+                mstore(pointerOffset, add(dataStart, mul(i, 0x80)))
             }
+            mstore(0x40, add(pointerOffset, 0x20))
         }
 
-        assembly {
-            mstore(ticks, count)
+        uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
+        for (uint256 i = 0; i < ticks.length; i++) {
+            uint256 requiredCurrencyDemandQ96;
+            if (remainingMps > 0) {
+                requiredCurrencyDemandQ96 =
+                    remainingSupplyQ96X7.fullMulDivUp(ticks[i].priceQ96, requiredDemandDenominator);
+            }
+            ticks[i].requiredCurrencyDemandQ96 = requiredCurrencyDemandQ96;
+            ticks[i].currencyRequiredQ96 =
+                requiredCurrencyDemandQ96.saturatingSub(runningDemand).fullMulDivUp(remainingMps, mps);
+            runningDemand -= ticks[i].currencyDemandQ96;
         }
     }
 }

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -35,7 +35,6 @@ contract TickDataLens {
         view
         returns (TickWithData[] memory ticks)
     {
-        uint256 totalSupply = auction.totalSupply();
         uint24 mps = ConstantsLib.MPS;
         uint24 remainingMps = mps - auction.latestCheckpoint().cumulativeMps;
         // Retrieve the sumCurrencyDemandAboveClearingQ96 from storage
@@ -47,11 +46,10 @@ contract TickDataLens {
             let m := mload(0x40)
             let offset := m
 
-            // Cache the ticks function selector
             let idx := 0
-            mstore(0x00, 0x534cb30d) // ContinuousClearingAuction.ticks(uint256)
             for {} lt(idx, MAX_BUFFER_SIZE) { idx := add(idx, 1) } {
                 // Store the next tick price as the first argument to the ticks function call
+                mstore(0x00, 0x534cb30d) // ContinuousClearingAuction.ticks(uint256)
                 mstore(0x20, next)
                 // Call the ticks function - write the return value directly at the offset
                 let success := staticcall(gas(), auction, 0x1c, 0x24, offset, 0x40)
@@ -64,9 +62,14 @@ contract TickDataLens {
                 // Overwrite the next tick price with the current tick price
                 mstore(offset, next)
 
-                // Calculate and store the requiredCurrencyDemandQ96
-                let requiredCurrencyDemandQ96 := mul(totalSupply, next)
-                mstore(add(offset, 0x40), requiredCurrencyDemandQ96)
+                // Calculate and store the requiredCurrencyDemandQ96 using the auction's rollover-aware formula
+                mstore(0x00, 0x5ba38798) // ContinuousClearingAuction.requiredDemandQ96(uint256)
+                mstore(0x20, next)
+                success := staticcall(gas(), auction, 0x1c, 0x24, add(offset, 0x40), 0x20)
+                if iszero(success) {
+                    revert(0x00, 0x00)
+                }
+                let requiredCurrencyDemandQ96 := mload(add(offset, 0x40))
 
                 // Calculate and store the currencyRequiredQ96:
                 // currencyRequiredQ96 = saturatingSub(required, sum).mulDivUp(remainingMps, MPS)

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -5,7 +5,6 @@ import {IContinuousClearingAuction} from '../interfaces/IContinuousClearingAucti
 import {ConstantsLib} from '../libraries/ConstantsLib.sol';
 import {FixedPoint96} from '../libraries/FixedPoint96.sol';
 import {ValueX7} from '../libraries/ValueX7Lib.sol';
-import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 
 /// @notice Tick data with additional computed values
 /// @dev Use the ratio between `sumCurrencyDemandAboveClearingQ96` in the auction
@@ -21,8 +20,6 @@ struct TickWithData {
 /// @title TickDataLens
 /// @notice Contract for reading data from initialized ticks of an auction
 contract TickDataLens {
-    using FixedPointMathLib for uint256;
-
     /// @notice The maximum number of initialized ticks which can be returned
     uint256 public constant MAX_BUFFER_SIZE = 1000;
 
@@ -45,8 +42,8 @@ contract TickDataLens {
         uint24 remainingMps = mps - auction.latestCheckpoint().cumulativeMps;
         uint256 remainingSupplyQ96X7 = ValueX7.unwrap(auction.remainingSupplyQ96X7());
         uint256 requiredDemandDenominator = FixedPoint96.Q96 * remainingMps;
-        // Retrieve the sumCurrencyDemandAboveClearingQ96 from storage
-        uint256 sumCurrencyDemandAboveClearingQ96 = auction.sumCurrencyDemandAboveClearingQ96();
+        // Seed the running demand from the auction's accumulator; it decays per tick below
+        uint256 runningDemand = auction.sumCurrencyDemandAboveClearingQ96();
 
         // Dynamically build the array of ticks to the length of the number of initialized ticks
         // done in assembly to prevent large memory expansion costs
@@ -61,15 +58,36 @@ contract TickDataLens {
 
                 let success := staticcall(gas(), auction, 0x1c, 0x24, dataOffset, 0x40)
                 if iszero(success) {
-                    revert(0x00, 0x00)
+                    // Bubble up the inner revert reason so off-chain callers see the auction's error
+                    returndatacopy(0, 0, returndatasize())
+                    revert(0, returndatasize())
                 }
 
                 let nextTick := mload(dataOffset)
                 mstore(dataOffset, next)
-                mstore(add(dataOffset, 0x40), 0)
-                mstore(add(dataOffset, 0x60), 0)
+
+                // requiredCurrencyDemandQ96 = remainingMps > 0
+                //     ? ceil(remainingSupplyQ96X7 * next / (Q96 * remainingMps)) (full 512-bit)
+                //     : 0
+                // Guarded explicitly so the d == 0 case never reaches fullMulDivUp.
+                let requiredCurrencyDemandQ96 := 0
+                if gt(remainingMps, 0) {
+                    requiredCurrencyDemandQ96 := fullMulDivUp(remainingSupplyQ96X7, next, requiredDemandDenominator)
+                }
+                mstore(add(dataOffset, 0x40), requiredCurrencyDemandQ96)
+
+                // currencyRequiredQ96 = ceil(saturatingSub(required, runningDemand) * remainingMps / mps)
+                mstore(
+                    add(dataOffset, 0x60),
+                    fullMulDivUp(saturatingSub(requiredCurrencyDemandQ96, runningDemand), remainingMps, mps)
+                )
 
                 next := nextTick
+                // Defensive: clamp to zero rather than wrapping if the auction's sum is
+                // ever inconsistent with per-tick demands (invariant should hold, but
+                // silent wrap would corrupt every subsequent tick's currencyRequiredQ96).
+                runningDemand := saturatingSub(runningDemand, /* currencyDemandQ96 */ mload(add(dataOffset, 0x20)))
+
                 dataOffset := add(dataOffset, 0x80)
 
                 if eq(nextTick, not(0)) {
@@ -87,20 +105,58 @@ contract TickDataLens {
                 mstore(pointerOffset, add(dataStart, mul(i, 0x80)))
             }
             mstore(0x40, add(pointerOffset, 0x20))
-        }
 
-        // Compute values over the initialized ticks
-        uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
-        for (uint256 i = 0; i < ticks.length; i++) {
-            uint256 requiredCurrencyDemandQ96;
-            if (remainingMps > 0) {
-                requiredCurrencyDemandQ96 =
-                    remainingSupplyQ96X7.fullMulDivUp(ticks[i].priceQ96, requiredDemandDenominator);
+            // ----- Inline functions -----
+            // ------------------------------------------------------------
+
+            /// @dev Equivalent to FixedPointMathLib.saturatingSub: returns max(0, x - y).
+            function saturatingSub(x, y) -> z {
+                z := mul(gt(x, y), sub(x, y))
             }
-            ticks[i].requiredCurrencyDemandQ96 = requiredCurrencyDemandQ96;
-            ticks[i].currencyRequiredQ96 =
-                requiredCurrencyDemandQ96.saturatingSub(runningDemand).fullMulDivUp(remainingMps, mps);
-            runningDemand -= ticks[i].currencyDemandQ96;
+
+            /// @dev Equivalent to FixedPointMathLib.fullMulDivUp: returns ceil(x * y / d)
+            ///      computed through a 512-bit intermediate. Mirrors Solady's
+            ///      implementation; reverts via `FullMulDivFailed()` if the result
+            ///      cannot fit in a uint256 (which also catches `d == 0` whenever
+            ///      `x * y` overflows uint256).
+            function fullMulDivUp(x, y, d) -> z {
+                z := mul(x, y)
+                for {} 1 {} {
+                    if iszero(mul(or(iszero(x), eq(div(z, x), y)), d)) {
+                        let mm := mulmod(x, y, not(0))
+                        let p1 := sub(mm, add(z, lt(mm, z)))
+                        let r := mulmod(x, y, d)
+                        let t := and(d, sub(0, d))
+                        if iszero(gt(d, p1)) {
+                            mstore(0x00, 0xae47f702) // `FullMulDivFailed()`
+                            revert(0x1c, 0x04)
+                        }
+                        d := div(d, t)
+                        let inv := xor(2, mul(3, d))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        inv := mul(inv, sub(2, mul(d, inv)))
+                        z := mul(
+                            or(mul(sub(p1, gt(r, z)), add(div(sub(0, t), t), 1)), div(sub(z, r), t)),
+                            mul(sub(2, mul(d, inv)), inv)
+                        )
+                        break
+                    }
+                    z := div(z, d)
+                    break
+                }
+                if mulmod(x, y, d) {
+                    z := add(z, 1)
+                    if iszero(z) {
+                        mstore(0x00, 0xae47f702) // `FullMulDivFailed()`
+                        revert(0x1c, 0x04)
+                    }
+                }
+            }
+
+            // ------------------------------------------------------------
         }
     }
 }

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -34,18 +34,19 @@ contract TickDataLens {
         view
         returns (TickWithData[] memory ticks)
     {
+        // Get the next active tick price
+        uint256 next = auction.nextActiveTickPrice();
+
+        if (next == type(uint256).max) {
+            return new TickWithData[](0);
+        }
+
         uint24 mps = ConstantsLib.MPS;
         uint24 remainingMps = mps - auction.latestCheckpoint().cumulativeMps;
         uint256 remainingSupplyQ96X7 = ValueX7.unwrap(auction.remainingSupplyQ96X7());
         uint256 requiredDemandDenominator = FixedPoint96.Q96 * remainingMps;
         // Retrieve the sumCurrencyDemandAboveClearingQ96 from storage
         uint256 sumCurrencyDemandAboveClearingQ96 = auction.sumCurrencyDemandAboveClearingQ96();
-        // Get the next active tick price
-        uint256 next = auction.nextActiveTickPrice();
-
-        if (next == type(uint256).max) {
-            revert();
-        }
 
         // Dynamically build the array of ticks to the length of the number of initialized ticks
         // done in assembly to prevent large memory expansion costs

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -48,27 +48,17 @@ contract TickDataLens {
             revert();
         }
 
-        uint256 count;
+        ticks = new TickWithData[](MAX_BUFFER_SIZE);
         uint256 tickPrice = next;
-        while (count < MAX_BUFFER_SIZE) {
-            Tick memory tick = auction.ticks(tickPrice);
-            count++;
-            tickPrice = tick.next;
-            if (tickPrice == type(uint256).max) {
-                break;
-            }
-        }
-
-        ticks = new TickWithData[](count);
-        tickPrice = next;
         uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
-        for (uint256 i = 0; i < count; i++) {
+        uint256 count;
+        while (count < ticks.length) {
             Tick memory tick = auction.ticks(tickPrice);
             uint256 requiredCurrencyDemandQ96;
             if (remainingMps > 0) {
                 requiredCurrencyDemandQ96 = remainingSupplyQ96X7.fullMulDivUp(tickPrice, requiredDemandDenominator);
             }
-            ticks[i] = TickWithData({
+            ticks[count] = TickWithData({
                 priceQ96: tickPrice,
                 currencyDemandQ96: tick.currencyDemandQ96,
                 requiredCurrencyDemandQ96: requiredCurrencyDemandQ96,
@@ -77,6 +67,14 @@ contract TickDataLens {
             });
             runningDemand -= tick.currencyDemandQ96;
             tickPrice = tick.next;
+            count++;
+            if (tickPrice == type(uint256).max) {
+                break;
+            }
+        }
+
+        assembly {
+            mstore(ticks, count)
         }
     }
 }

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -24,7 +24,7 @@ struct TickWithData {
 /// @title TickDataLens
 /// @notice Contract for reading data from initialized ticks of an auction
 contract TickDataLens {
-    using FixedPointMathLib for *;
+    using FixedPointMathLib for uint256;
 
     /// @notice The maximum number of initialized ticks which can be returned
     uint256 public constant MAX_BUFFER_SIZE = 1000;
@@ -66,28 +66,6 @@ contract TickDataLens {
                 // Overwrite the next tick price with the current tick price
                 mstore(offset, next)
 
-                // Calculate and store the requiredCurrencyDemandQ96 using the auction's rollover-aware formula:
-                // fullMulDivUp(remainingSupplyQ96X7, priceQ96, Q96 * remainingMps)
-                let requiredCurrencyDemandQ96 := 0
-                if remainingMps {
-                    requiredCurrencyDemandQ96 := fullMulDivUp(remainingSupplyQ96X7, next, requiredDemandDenominator)
-                }
-                mstore(add(offset, 0x40), requiredCurrencyDemandQ96)
-
-                // Calculate and store the currencyRequiredQ96:
-                // currencyRequiredQ96 = saturatingSub(required, sum).mulDivUp(remainingMps, MPS)
-                let currencyRequiredQ96 :=
-                    mulDivUp(
-                        saturatingSub(requiredCurrencyDemandQ96, sumCurrencyDemandAboveClearingQ96),
-                        remainingMps,
-                        mps
-                    )
-                mstore(add(offset, 0x60), currencyRequiredQ96)
-
-                // update sumCurrencyDemandAboveClearingQ96 by subtracting the currencyDemandQ96 at the current tick
-                let currencyDemandQ96 := mload(add(offset, 0x20))
-                sumCurrencyDemandAboveClearingQ96 := sub(sumCurrencyDemandAboveClearingQ96, currencyDemandQ96)
-
                 // update next to the next tick price returned by the ticks function
                 next := nextTick
 
@@ -114,66 +92,19 @@ contract TickDataLens {
             }
             // Update the free memory pointer to the end of the data
             mstore(0x40, add(offset, 0x20))
+        }
 
-            // ----- Inline functions -----
-            // ------------------------------------------------------------
-
-            /// @dev Equivalent to FixedPointMathLib.saturatingSub: returns max(0, x - y).
-            function saturatingSub(x, y) -> z {
-                z := mul(gt(x, y), sub(x, y))
+        uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
+        for (uint256 i = 0; i < ticks.length; i++) {
+            uint256 requiredCurrencyDemandQ96;
+            if (remainingMps > 0) {
+                requiredCurrencyDemandQ96 =
+                    remainingSupplyQ96X7.fullMulDivUp(ticks[i].priceQ96, requiredDemandDenominator);
             }
-
-            /// @dev Equivalent to FixedPointMathLib.fullMulDivUp: returns ceil(x * y / d).
-            ///      Safe to use a plain `mul` instead of 512-bit math because `y` is
-            ///      `remainingMps` (a uint24, max 1e7 ≈ 2^23), so x * y cannot overflow
-            ///      uint256 for any realistic currency demand value.
-            function mulDivUp(x, y, d) -> result {
-                result := div(mul(x, y), d)
-                if mulmod(x, y, d) {
-                    result := add(result, 1)
-                }
-            }
-
-            /// @dev Equivalent to FixedPointMathLib.fullMulDivUp: returns ceil(x * y / d).
-            function fullMulDivUp(x, y, d) -> result {
-                let denominator := d
-                result := mul(x, y)
-                for {} 1 {} {
-                    if iszero(mul(or(iszero(x), eq(div(result, x), y)), d)) {
-                        let mm := mulmod(x, y, not(0))
-                        let p1 := sub(mm, add(result, lt(mm, result)))
-                        let r := mulmod(x, y, d)
-                        let t := and(d, sub(0, d))
-                        if iszero(gt(d, p1)) {
-                            mstore(0x00, 0xae47f702) // FullMulDivFailed()
-                            revert(0x1c, 0x04)
-                        }
-                        d := div(d, t)
-                        let inv := xor(2, mul(3, d))
-                        inv := mul(inv, sub(2, mul(d, inv)))
-                        inv := mul(inv, sub(2, mul(d, inv)))
-                        inv := mul(inv, sub(2, mul(d, inv)))
-                        inv := mul(inv, sub(2, mul(d, inv)))
-                        inv := mul(inv, sub(2, mul(d, inv)))
-                        result := mul(
-                            or(mul(sub(p1, gt(r, result)), add(div(sub(0, t), t), 1)), div(sub(result, r), t)),
-                            mul(sub(2, mul(d, inv)), inv)
-                        )
-                        break
-                    }
-                    result := div(result, d)
-                    break
-                }
-                if mulmod(x, y, denominator) {
-                    result := add(result, 1)
-                    if iszero(result) {
-                        mstore(0x00, 0xae47f702) // FullMulDivFailed()
-                        revert(0x1c, 0x04)
-                    }
-                }
-            }
-
-            // ------------------------------------------------------------
+            ticks[i].requiredCurrencyDemandQ96 = requiredCurrencyDemandQ96;
+            ticks[i].currencyRequiredQ96 =
+                requiredCurrencyDemandQ96.saturatingSub(runningDemand).fullMulDivUp(remainingMps, mps);
+            runningDemand -= ticks[i].currencyDemandQ96;
         }
     }
 }

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -47,6 +47,8 @@ contract TickDataLens {
             revert();
         }
 
+        // Dynamically build the array of ticks to the length of the number of initialized ticks
+        // done in assembly to prevent large memory expansion costs
         assembly {
             let dataStart := mload(0x40)
             let dataOffset := dataStart
@@ -86,6 +88,7 @@ contract TickDataLens {
             mstore(0x40, add(pointerOffset, 0x20))
         }
 
+        // Compute values over the initialized ticks
         uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
         for (uint256 i = 0; i < ticks.length; i++) {
             uint256 requiredCurrencyDemandQ96;

--- a/src/lens/TickDataLens.sol
+++ b/src/lens/TickDataLens.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import {TickStorage} from '../TickStorage.sol';
 import {IContinuousClearingAuction} from '../interfaces/IContinuousClearingAuction.sol';
 import {Tick} from '../interfaces/ITickStorage.sol';
 import {ConstantsLib} from '../libraries/ConstantsLib.sol';
 import {FixedPoint96} from '../libraries/FixedPoint96.sol';
 import {ValueX7} from '../libraries/ValueX7Lib.sol';
-import {AuctionState} from './AuctionStateLens.sol';
 import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 
 /// @notice Tick data with additional computed values
@@ -46,65 +44,39 @@ contract TickDataLens {
         // Get the next active tick price
         uint256 next = auction.nextActiveTickPrice();
 
-        assembly {
-            let m := mload(0x40)
-            let offset := m
-
-            let idx := 0
-            for {} lt(idx, MAX_BUFFER_SIZE) { idx := add(idx, 1) } {
-                // Store the next tick price as the first argument to the ticks function call
-                mstore(0x00, 0x534cb30d) // ContinuousClearingAuction.ticks(uint256)
-                mstore(0x20, next)
-                // Call the ticks function - write the return value directly at the offset
-                let success := staticcall(gas(), auction, 0x1c, 0x24, offset, 0x40)
-                // If the call fails, revert
-                if iszero(success) {
-                    revert(0x00, 0x00)
-                }
-                // Load the next tick price from the return value
-                let nextTick := mload(offset)
-                // Overwrite the next tick price with the current tick price
-                mstore(offset, next)
-
-                // update next to the next tick price returned by the ticks function
-                next := nextTick
-
-                // update offset to the next tick data
-                offset := add(offset, 0x80)
-
-                // If the next tick price is the maximum uint256 value or we have reached the maximum buffer size, break the loop
-                if eq(nextTick, not(0)) {
-                    // Update idx to the number of ticks returned
-                    idx := add(idx, 1)
-                    break
-                }
-            }
-
-            // Assign the return value to the right memory location
-            ticks := offset
-            // Assign the length of the TickWithData array to the first word of the return value
-            mstore(ticks, idx)
-            // Assign the absolute pointers after the length to the return value
-            for { let i := 0 } lt(i, idx) { i := add(i, 1) } {
-                offset := add(offset, 0x20)
-                let absolutePointer := add(m, mul(i, 0x80))
-                mstore(offset, absolutePointer)
-            }
-            // Update the free memory pointer to the end of the data
-            mstore(0x40, add(offset, 0x20))
+        if (next == type(uint256).max) {
+            revert();
         }
 
+        uint256 count;
+        uint256 tickPrice = next;
+        while (count < MAX_BUFFER_SIZE) {
+            Tick memory tick = auction.ticks(tickPrice);
+            count++;
+            tickPrice = tick.next;
+            if (tickPrice == type(uint256).max) {
+                break;
+            }
+        }
+
+        ticks = new TickWithData[](count);
+        tickPrice = next;
         uint256 runningDemand = sumCurrencyDemandAboveClearingQ96;
-        for (uint256 i = 0; i < ticks.length; i++) {
+        for (uint256 i = 0; i < count; i++) {
+            Tick memory tick = auction.ticks(tickPrice);
             uint256 requiredCurrencyDemandQ96;
             if (remainingMps > 0) {
-                requiredCurrencyDemandQ96 =
-                    remainingSupplyQ96X7.fullMulDivUp(ticks[i].priceQ96, requiredDemandDenominator);
+                requiredCurrencyDemandQ96 = remainingSupplyQ96X7.fullMulDivUp(tickPrice, requiredDemandDenominator);
             }
-            ticks[i].requiredCurrencyDemandQ96 = requiredCurrencyDemandQ96;
-            ticks[i].currencyRequiredQ96 =
-                requiredCurrencyDemandQ96.saturatingSub(runningDemand).fullMulDivUp(remainingMps, mps);
-            runningDemand -= ticks[i].currencyDemandQ96;
+            ticks[i] = TickWithData({
+                priceQ96: tickPrice,
+                currencyDemandQ96: tick.currencyDemandQ96,
+                requiredCurrencyDemandQ96: requiredCurrencyDemandQ96,
+                currencyRequiredQ96: requiredCurrencyDemandQ96.saturatingSub(runningDemand)
+                    .fullMulDivUp(remainingMps, mps)
+            });
+            runningDemand -= tick.currencyDemandQ96;
+            tickPrice = tick.next;
         }
     }
 }

--- a/test/lens/TickDataLens.t.sol
+++ b/test/lens/TickDataLens.t.sol
@@ -19,9 +19,10 @@ contract TickDataLensTest is AuctionUnitTest {
         lens = new TickDataLens();
     }
 
-    function test_getInitializedTickData_revertsWhenNoTicksAboveClearing() public {
-        vm.expectRevert();
-        lens.getInitializedTickData(IContinuousClearingAuction(address(mockAuction)));
+    function test_getInitializedTickData_returnsEmptyWhenNoTicksAboveClearing() public view {
+        TickWithData[] memory ticks = lens.getInitializedTickData(IContinuousClearingAuction(address(mockAuction)));
+
+        assertEq(ticks.length, 0);
     }
 
     function test_getInitializedTickData_singleTick() public {

--- a/test/lens/TickDataLens.t.sol
+++ b/test/lens/TickDataLens.t.sol
@@ -36,10 +36,10 @@ contract TickDataLensTest is AuctionUnitTest {
         assertEq(ticks[0].priceQ96, price);
         assertEq(ticks[0].currencyDemandQ96, demand);
 
-        uint256 expectedRequired = uint256(TOTAL_SUPPLY) * price;
+        uint256 expectedRequired = _expectedRequiredDemand(price);
         assertEq(ticks[0].requiredCurrencyDemandQ96, expectedRequired);
 
-        uint256 expectedCurrencyRequired = expectedRequired.saturatingSub(demand);
+        uint256 expectedCurrencyRequired = _expectedCurrencyRequired(expectedRequired, demand);
         assertEq(ticks[0].currencyRequiredQ96, expectedCurrencyRequired);
     }
 
@@ -64,21 +64,21 @@ contract TickDataLensTest is AuctionUnitTest {
         // First tick: sumDemand includes demand at both ticks
         assertEq(ticks[0].priceQ96, price1);
         assertEq(ticks[0].currencyDemandQ96, demand1);
-        uint256 required1 = uint256(TOTAL_SUPPLY) * price1;
+        uint256 required1 = _expectedRequiredDemand(price1);
         assertEq(ticks[0].requiredCurrencyDemandQ96, required1);
-        assertEq(ticks[0].currencyRequiredQ96, required1.saturatingSub(totalDemand));
+        assertEq(ticks[0].currencyRequiredQ96, _expectedCurrencyRequired(required1, totalDemand));
 
         // Second tick: sumDemand has been reduced by demand1
         assertEq(ticks[1].priceQ96, price2);
         assertEq(ticks[1].currencyDemandQ96, demand2);
-        uint256 required2 = uint256(TOTAL_SUPPLY) * price2;
+        uint256 required2 = _expectedRequiredDemand(price2);
         assertEq(ticks[1].requiredCurrencyDemandQ96, required2);
-        assertEq(ticks[1].currencyRequiredQ96, required2.saturatingSub(demand2));
+        assertEq(ticks[1].currencyRequiredQ96, _expectedCurrencyRequired(required2, demand2));
     }
 
     function test_getInitializedTickData_currencyRequiredIsZeroWhenDemandExceedsRequired() public {
         uint256 price = params.floorPrice + params.tickSpacing;
-        uint256 requiredDemand = uint256(TOTAL_SUPPLY) * price;
+        uint256 requiredDemand = _expectedRequiredDemand(price);
         uint256 demand = requiredDemand * 2;
 
         _initializeTick(price, demand);
@@ -105,8 +105,12 @@ contract TickDataLensTest is AuctionUnitTest {
 
         // After 1 block at STANDARD_MPS_1_PERCENT, cumulativeMps = STANDARD_MPS_1_PERCENT
         uint24 expectedRemainingMps = ConstantsLib.MPS - STANDARD_MPS_1_PERCENT;
-        uint256 shortfall = (uint256(TOTAL_SUPPLY) * price).saturatingSub(demand);
+        uint256 expectedRequiredDemand = _expectedRequiredDemand(price);
+        assertGt(expectedRequiredDemand, uint256(TOTAL_SUPPLY) * price);
+
+        uint256 shortfall = expectedRequiredDemand.saturatingSub(demand);
         uint256 expectedCurrencyRequired = shortfall.fullMulDivUp(expectedRemainingMps, ConstantsLib.MPS);
+        assertEq(ticks[0].requiredCurrencyDemandQ96, expectedRequiredDemand);
         assertEq(ticks[0].currencyRequiredQ96, expectedCurrencyRequired);
     }
 
@@ -125,7 +129,7 @@ contract TickDataLensTest is AuctionUnitTest {
         assertEq(ticks.length, 1);
         assertEq(ticks[0].priceQ96, price);
         assertEq(ticks[0].currencyDemandQ96, demand);
-        assertEq(ticks[0].requiredCurrencyDemandQ96, uint256(TOTAL_SUPPLY) * price);
+        assertEq(ticks[0].requiredCurrencyDemandQ96, 0);
         // With remainingMps == 0, currencyRequired scales to 0
         assertEq(ticks[0].currencyRequiredQ96, 0);
     }
@@ -187,11 +191,11 @@ contract TickDataLensTest is AuctionUnitTest {
 
         uint256 runningDemand = totalDemand;
         for (uint256 i = 0; i < numTicks; i++) {
-            uint256 required = uint256(TOTAL_SUPPLY) * prices[i];
+            uint256 required = _expectedRequiredDemand(prices[i]);
             assertEq(ticks[i].priceQ96, prices[i]);
             assertEq(ticks[i].currencyDemandQ96, demands[i]);
             assertEq(ticks[i].requiredCurrencyDemandQ96, required);
-            assertEq(ticks[i].currencyRequiredQ96, required.saturatingSub(runningDemand));
+            assertEq(ticks[i].currencyRequiredQ96, _expectedCurrencyRequired(required, runningDemand));
             runningDemand -= demands[i];
         }
     }
@@ -206,11 +210,11 @@ contract TickDataLensTest is AuctionUnitTest {
 
         uint256 runningDemand = totalDemand;
         for (uint256 i = 0; i < numTicks; i++) {
-            uint256 required = uint256(TOTAL_SUPPLY) * prices[i];
+            uint256 required = _expectedRequiredDemand(prices[i]);
             assertEq(ticks[i].priceQ96, prices[i]);
             assertEq(ticks[i].currencyDemandQ96, demands[i]);
             assertEq(ticks[i].requiredCurrencyDemandQ96, required);
-            assertEq(ticks[i].currencyRequiredQ96, required.saturatingSub(runningDemand));
+            assertEq(ticks[i].currencyRequiredQ96, _expectedCurrencyRequired(required, runningDemand));
             runningDemand -= demands[i];
         }
     }
@@ -244,5 +248,14 @@ contract TickDataLensTest is AuctionUnitTest {
         }
         mockAuction.uncheckedSetNextActiveTickPrice(prices[0]);
         mockAuction.uncheckedSetSumDemandAboveClearing(totalDemand);
+    }
+
+    function _expectedRequiredDemand(uint256 price) internal view returns (uint256) {
+        return mockAuction.requiredDemandQ96(price);
+    }
+
+    function _expectedCurrencyRequired(uint256 requiredDemand, uint256 runningDemand) internal view returns (uint256) {
+        uint24 remainingMps = ConstantsLib.MPS - mockAuction.latestCheckpoint().cumulativeMps;
+        return requiredDemand.saturatingSub(runningDemand).fullMulDivUp(remainingMps, ConstantsLib.MPS);
     }
 }


### PR DESCRIPTION
## Summary
- Updates `TickDataLens` to read required demand from the auction's rollover-aware `requiredDemandQ96(price)` helper instead of using the pre-rollover `TOTAL_SUPPLY * price` shortcut.
- Keeps `currencyRequiredQ96` based on the remaining MPS schedule and updates lens tests for rollover, exhausted schedule, and fuzz expectations.

## Test plan
- `forge test --match-contract TickDataLensTest -vvv`


Made with [Cursor](https://cursor.com)