### PR TITLE
fix: tighten min floor price inverse boundary

### DIFF
--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -15,9 +15,9 @@ library ConstantsLib {
     ///         which would restrict the clearing price to be a very low price in the calculation below.
     uint128 constant MAX_TOTAL_SUPPLY = 1 << 100;
 
-    /// @notice The minimum allowable floor price is type(uint32).max + 1
-    /// @dev This is the minimum price that fits in a uint160 after being inversed
-    uint256 constant MIN_FLOOR_PRICE = uint256(type(uint32).max) + 1;
+    /// @notice The minimum allowable floor price is 2^32 + 1
+    /// @dev Ensures the Q96 reciprocal `(1 << 192) / priceX96` fits in a uint160
+    uint256 constant MIN_FLOOR_PRICE = (1 << 32) + 1;
 
     /// @notice The minimum allowable tick spacing
     /// @dev We don't support tick spacings of 1 to avoid edge cases where the rounding of the clearing price

--- a/test/btt/auction/constructor.t.sol
+++ b/test/btt/auction/constructor.t.sol
@@ -62,7 +62,7 @@ contract ConstructorTest is BttBase {
 
         // Just to pass checks
         mParams.parameters.floorPrice = ConstantsLib.MIN_FLOOR_PRICE;
-        mParams.parameters.tickSpacing = ConstantsLib.MIN_TICK_SPACING;
+        mParams.parameters.tickSpacing = ConstantsLib.MIN_FLOOR_PRICE;
 
         ContinuousClearingAuction auction =
             new ContinuousClearingAuction(mParams.token, mParams.totalSupply, mParams.parameters);
@@ -114,7 +114,7 @@ contract ConstructorTest is BttBase {
         );
 
         mParams.parameters.floorPrice = ConstantsLib.MIN_FLOOR_PRICE;
-        mParams.parameters.tickSpacing = ConstantsLib.MIN_TICK_SPACING;
+        mParams.parameters.tickSpacing = ConstantsLib.MIN_FLOOR_PRICE;
 
         ContinuousClearingAuction auction =
             new ContinuousClearingAuction(mParams.token, mParams.totalSupply, mParams.parameters);

--- a/test/btt/tickstorage/constructor.t.sol
+++ b/test/btt/tickstorage/constructor.t.sol
@@ -53,6 +53,12 @@ contract ConstructorTest is BttBase {
         new MockTickStorage(_tickSpacing, _floorPrice);
     }
 
+    function test_MinFloorPriceReciprocalFitsUint160() external pure {
+        uint256 excludedBoundary = 1 << 32;
+        assertEq((1 << 192) / excludedBoundary, uint256(type(uint160).max) + 1);
+        assertLe((1 << 192) / ConstantsLib.MIN_FLOOR_PRICE, type(uint160).max);
+    }
+
     modifier whenFloorPriceGTEMinFloorPrice() {
         _;
         assertGe(floorPrice, ConstantsLib.MIN_FLOOR_PRICE, 'floor price is less than min floor price');


### PR DESCRIPTION
## Summary
- Increase `MIN_FLOOR_PRICE` to `2^32 + 1` so its Q96 reciprocal fits within `uint160`.
- Update comments to document the reciprocal safety invariant directly.
- Add a regression test for the excluded `2^32` boundary and adjust constructor tests for the odd minimum floor price.

## Test plan
- `forge test --match-path 'test/btt/tickstorage/constructor.t.sol'`
- `forge test --match-path 'test/btt/auction/constructor.t.sol'`

Made with [Cursor](https://cursor.com)