### PR TITLE
OZ-L01: Return zero for empty next active tick demand

### DIFF
--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -697,6 +697,7 @@ contract ContinuousClearingAuction is
 
     /// @inheritdoc IContinuousClearingAuction
     function requiredDemandQ96AtNextActiveTick() public view returns (uint256) {
+        if ($nextActiveTickPrice == MAX_TICK_PTR) return 0;
         return requiredDemandQ96($nextActiveTickPrice);
     }
 

--- a/src/TickStorage.sol
+++ b/src/TickStorage.sol
@@ -11,7 +11,7 @@ abstract contract TickStorage is ITickStorage {
     mapping(uint256 price => Tick) private $_ticks;
 
     /// @notice The price of the next initialized tick above the clearing price
-    /// @dev This will be equal to the clearingPrice if no ticks have been initialized yet
+    /// @dev This will be equal to MAX_TICK_PTR if no ticks above the clearing price are active
     uint256 internal $nextActiveTickPrice;
     /// @notice The floor price of the auction
     uint256 internal immutable FLOOR_PRICE;

--- a/src/interfaces/IContinuousClearingAuction.sol
+++ b/src/interfaces/IContinuousClearingAuction.sol
@@ -242,5 +242,6 @@ interface IContinuousClearingAuction is
 
     /// @notice The required demand to move the auction to the next active tick, in Q96 representation
     /// @dev Relies on the latest checkpoint which may be out of date
+    /// @dev Returns zero when there is no next active tick
     function requiredDemandQ96AtNextActiveTick() external view returns (uint256);
 }

--- a/src/interfaces/ITickStorage.sol
+++ b/src/interfaces/ITickStorage.sol
@@ -39,7 +39,7 @@ interface ITickStorage {
     event NextActiveTickUpdated(uint256 price);
 
     /// @notice The price of the next initialized tick above the clearing price
-    /// @dev This will be equal to the clearingPrice if no ticks have been initialized yet
+    /// @dev This will be equal to MAX_TICK_PTR if no ticks above the clearing price are active
     /// @return The price of the next active tick
     function nextActiveTickPrice() external view returns (uint256);
 

--- a/test/btt/auction/requiredDemandQ96AtNextActiveTick.t.sol
+++ b/test/btt/auction/requiredDemandQ96AtNextActiveTick.t.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import {AuctionFuzzConstructorParams, BttBase} from '../BttBase.sol';
+
+import {ContinuousClearingAuction} from 'src/ContinuousClearingAuction.sol';
+
+contract RequiredDemandQ96AtNextActiveTickTest is BttBase {
+    function test_WhenNextActiveTickPriceIsMaxTickPtr(AuctionFuzzConstructorParams memory _params)
+        external
+        setupAuctionConstructorParams(_params)
+    {
+        // it returns 0
+
+        ContinuousClearingAuction auction =
+            new ContinuousClearingAuction(_params.token, _params.totalSupply, _params.parameters, address(0));
+
+        assertEq(auction.nextActiveTickPrice(), auction.MAX_TICK_PTR());
+        assertEq(auction.requiredDemandQ96AtNextActiveTick(), 0);
+    }
+}

--- a/test/btt/auction/requiredDemandQ96AtNextActiveTick.tree
+++ b/test/btt/auction/requiredDemandQ96AtNextActiveTick.tree
@@ -1,0 +1,3 @@
+RequiredDemandQ96AtNextActiveTickTest
+└── when nextActiveTickPrice is MAX_TICK_PTR
+    └── it returns 0


### PR DESCRIPTION
## OZ-L01 — Return zero for empty next active tick demand

### Issue
`requiredDemandQ96AtNextActiveTick()` returned `requiredDemandQ96($nextActiveTickPrice)` unconditionally. When there is no active tick above the clearing price, `$nextActiveTickPrice` is the `MAX_TICK_PTR` sentinel, so the getter computed required demand against a meaningless sentinel price and returned a misleading value to offchain consumers.

### Fix
Short-circuit and return `0` when `$nextActiveTickPrice == MAX_TICK_PTR`, i.e. when no next active tick exists. NatSpec on `requiredDemandQ96AtNextActiveTick` and `nextActiveTickPrice`, plus the `$nextActiveTickPrice` docs, are corrected to reflect that the sentinel is `MAX_TICK_PTR` (not the clearing price) and that the getter returns zero in that case.

### Tests
Added BTT coverage in `requiredDemandQ96AtNextActiveTick.t.sol` for the empty-next-active-tick case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)