### PR TITLE
OZ-L03: Checkpoint before validation hook

### DIFF
--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -352,12 +352,13 @@ contract ContinuousClearingAuction is
         // Reject bids which would cause TOTAL_SUPPLY * maxPrice to overflow a uint256
         if (_maxPrice > MAX_BID_PRICE) revert InvalidBidPriceTooHigh(_maxPrice, MAX_BID_PRICE);
 
-        // Call the validation hook and bubble up the revert reason if it reverts
-        VALIDATION_HOOK.handleValidate(_maxPrice, _amount, _owner, msg.sender, _hookData);
-
         // Get the latest checkpoint before validating the bid
         uint64 currentBlockNumberIsh = uint64(_getBlockNumberish());
         Checkpoint memory _checkpoint = _checkpointAtBlock(currentBlockNumberIsh);
+
+        // Call the validation hook and bubble up the revert reason if it reverts
+        VALIDATION_HOOK.handleValidate(_maxPrice, _amount, _owner, msg.sender, _hookData);
+
         // Revert if there are no more tokens to be sold
         if (_checkpoint.remainingMpsInAuction() == 0 || ValueX7.unwrap(_remainingSupplyQ96X7()) == 0) {
             revert AuctionSoldOut();

--- a/test/btt/auction/submitBid.t.sol
+++ b/test/btt/auction/submitBid.t.sol
@@ -15,6 +15,7 @@ import {FixedPoint96} from 'src/libraries/FixedPoint96.sol';
 import {ValidationHookLib} from 'src/libraries/ValidationHookLib.sol';
 import {ValueX7} from 'src/libraries/ValueX7Lib.sol';
 import {AuctionStepsBuilder} from 'test/utils/AuctionStepsBuilder.sol';
+import {MockCheckpointObservingValidationHook} from 'test/utils/MockCheckpointObservingValidationHook.sol';
 import {MockReenteringValidationHook} from 'test/utils/MockReenteringValidationHook.sol';
 
 contract SubmitBidTest is BttBase {
@@ -266,6 +267,36 @@ contract SubmitBidTest is BttBase {
 
     modifier givenValidationHookSucceeds() {
         _;
+    }
+
+    function test_WhenValidationHookSucceedsForFirstBidInNewBlock(AuctionFuzzConstructorParams memory _params)
+        public
+        givenBlockNumberIsBeforeEndBlock
+        givenBidOwnerIsNotZeroAddress
+        givenBidAmountGTZero
+        givenMaxPriceIsLTEMaxBidPrice
+        givenValidationHookSucceeds
+    {
+        // it calls the validation hook after checkpointing the current block
+
+        AuctionFuzzConstructorParams memory mParams = validAuctionConstructorInputs(_params);
+        mParams.token = address(new ERC20Mock());
+        mParams.parameters.currency = address(0);
+        MockCheckpointObservingValidationHook validationHook = new MockCheckpointObservingValidationHook();
+        mParams.parameters.validationHook = address(validationHook);
+
+        MockContinuousClearingAuction auction =
+            new MockContinuousClearingAuction(mParams.token, mParams.totalSupply, mParams.parameters, address(0));
+
+        ERC20Mock(mParams.token).mint(address(auction), requiredTokenDeposit(mParams));
+        auction.onTokensReceived();
+
+        uint256 maxPrice = mParams.parameters.floorPrice + mParams.parameters.tickSpacing;
+
+        vm.roll(mParams.parameters.startBlock);
+        auction.submitBid{value: 1}(maxPrice, 1, address(this), mParams.parameters.floorPrice, bytes(''));
+
+        assertEq(validationHook.observedLastCheckpointedBlock(), mParams.parameters.startBlock);
     }
 
     function test_WhenAuctionIsSoldOut(AuctionFuzzConstructorParams memory _params, uint256 _maxPrice)

--- a/test/btt/auction/submitBid.tree
+++ b/test/btt/auction/submitBid.tree
@@ -23,6 +23,8 @@ SubmitBidTest
                     ├── when validation hook reenters
                     │   └── it reverts with {Reentrancy}
                     └── given validation hook succeeds
+                        ├── when first bid in a new block
+                        │   └── it calls the validation hook after checkpointing the current block
                         ├── when auction is sold out
                         │   └── it reverts with {AuctionSoldOut}
                         └── when remaining tokens is zero

--- a/test/utils/MockCheckpointObservingValidationHook.sol
+++ b/test/utils/MockCheckpointObservingValidationHook.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {IValidationHook} from '../../src/interfaces/IValidationHook.sol';
+
+interface ILastCheckpointedBlock {
+    function lastCheckpointedBlock() external view returns (uint64);
+}
+
+/// @notice Mock validation hook that records auction checkpoint state during validation
+contract MockCheckpointObservingValidationHook is IValidationHook {
+    uint64 public observedLastCheckpointedBlock;
+
+    function validate(uint256, uint128, address, address, bytes calldata) external override {
+        observedLastCheckpointedBlock = ILastCheckpointedBlock(msg.sender).lastCheckpointedBlock();
+    }
+}


### PR DESCRIPTION
## OZ-L03 — Checkpoint before validation hook

### Issue
In `submitBid`, the external validation hook (`VALIDATION_HOOK.handleValidate`) was called *before* the auction state was checkpointed. This handed control to an external, potentially untrusted call while the auction state was still stale/un-checkpointed.

### Fix
Reorder so the latest checkpoint is taken (`_checkpointAtBlock`) before invoking the validation hook. The hook now runs against up-to-date auction state, and the sold-out check that follows uses the freshly computed checkpoint.

### Tests
Added `submitBid` BTT coverage with a `MockCheckpointObservingValidationHook` asserting the auction is checkpointed before the hook is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)