### PR TITLE
OZ-N01: Use ValueX7 operators

### DIFF
--- a/src/AuctionStorage.sol
+++ b/src/AuctionStorage.sol
@@ -138,7 +138,7 @@ abstract contract AuctionStorage is IAuctionStorage {
     }
 
     function _remainingSupplyQ96X7() internal view returns (ValueX7) {
-        return TOTAL_SUPPLY_Q96X7.sub($totalClearedQ96X7);
+        return TOTAL_SUPPLY_Q96X7 - $totalClearedQ96X7;
     }
 
     /// @inheritdoc IAuctionStorage

--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -167,7 +167,7 @@ contract ContinuousClearingAuction is
     /// @notice Whether the auction has graduated as of the given checkpoint
     /// @dev The auction is considered `graduated` if the currency raised is greater than or equal to the required currency raised
     function _isGraduated() internal view returns (bool) {
-        return ValueX7.unwrap($currencyRaisedQ96X7) >= ValueX7.unwrap(REQUIRED_CURRENCY_RAISED_Q96X7);
+        return $currencyRaisedQ96X7 >= REQUIRED_CURRENCY_RAISED_Q96X7;
     }
 
     /// @notice Iterate to find the tick where the total demand at and above it is strictly less than the remaining supply in the auction
@@ -300,10 +300,10 @@ contract ContinuousClearingAuction is
                             ConstantsLib.MPS - _checkpoint.cumulativeMps // guaranteed to be > 0 because deltaMps > 0
                         );
                         // Total change in currencyRaised = currency raised above clearing + currency raised at clearing
-                        currencyRaisedDeltaQ96X7 = currencyRaisedDeltaQ96X7.add(currencyRaisedAtClearingQ96X7);
+                        currencyRaisedDeltaQ96X7 = currencyRaisedDeltaQ96X7 + currencyRaisedAtClearingQ96X7;
                         // Track cumulative currency raised exactly at this clearing price (used for partial exits)
                         _checkpoint.currencyRaisedAtClearingPriceQ96X7 =
-                            _checkpoint.currencyRaisedAtClearingPriceQ96X7.add(currencyRaisedAtClearingQ96X7);
+                            _checkpoint.currencyRaisedAtClearingPriceQ96X7 + currencyRaisedAtClearingQ96X7;
                     }
                 }
 
@@ -312,10 +312,10 @@ contract ContinuousClearingAuction is
                 uint256 tokensClearedQ96X7 =
                     ValueX7.unwrap(currencyRaisedDeltaQ96X7).toTokensRoundingUp(clearingPriceQ96);
                 // Ensure that totalCleared is never greater than total supply.
-                $totalClearedQ96X7 = $totalClearedQ96X7.add(ValueX7.wrap(tokensClearedQ96X7)).min(TOTAL_SUPPLY_Q96X7);
+                $totalClearedQ96X7 = ($totalClearedQ96X7 + ValueX7.wrap(tokensClearedQ96X7)).min(TOTAL_SUPPLY_Q96X7);
 
                 // Update global currency raised
-                $currencyRaisedQ96X7 = $currencyRaisedQ96X7.add(currencyRaisedDeltaQ96X7);
+                $currencyRaisedQ96X7 = $currencyRaisedQ96X7 + currencyRaisedDeltaQ96X7;
 
                 // Add to the cumulative mps per price sum, weighted by `mps`. This is an inverse sum.
                 _checkpoint.cumulativeMpsPerPrice += (uint256(deltaMps) << 192) / clearingPriceQ96;

--- a/src/libraries/ValueX7Lib.sol
+++ b/src/libraries/ValueX7Lib.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
-
 /// @notice A ValueX7 is a uint256 value that has been multiplied by 1e7 (ConstantsLib.MPS)
 /// @dev X7 values are used for demand and supply values to defer division
 type ValueX7 is uint256;
 
-using {add, sub, min} for ValueX7 global;
+using {add as +, sub as -, gte as >=, min} for ValueX7 global;
 
 /// @notice Add two ValueX7 values and return the result as a ValueX7
 function add(ValueX7 a, ValueX7 b) pure returns (ValueX7) {
@@ -17,6 +15,11 @@ function add(ValueX7 a, ValueX7 b) pure returns (ValueX7) {
 /// @notice Subtract two ValueX7 values and return the result as a ValueX7
 function sub(ValueX7 a, ValueX7 b) pure returns (ValueX7) {
     return ValueX7.wrap(ValueX7.unwrap(a) - ValueX7.unwrap(b));
+}
+
+/// @notice Return true if a is greater than or equal to b
+function gte(ValueX7 a, ValueX7 b) pure returns (bool) {
+    return ValueX7.unwrap(a) >= ValueX7.unwrap(b);
 }
 
 /// @notice Return the minimum of two ValueX7 values

--- a/test/btt/libraries/valueX7Lib/operators.t.sol
+++ b/test/btt/libraries/valueX7Lib/operators.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import {BttBase} from 'btt/BttBase.sol';
+import {ValueX7} from 'continuous-clearing-auction/libraries/ValueX7Lib.sol';
+
+contract ValueX7OperatorsTest is BttBase {
+    function test_Add(ValueX7 _a, ValueX7 _b) external pure {
+        // it returns the sum of two ValueX7 values
+
+        uint256 a = bound(ValueX7.unwrap(_a), 0, type(uint256).max / 2);
+        uint256 b = bound(ValueX7.unwrap(_b), 0, type(uint256).max / 2);
+
+        assertEq(ValueX7.unwrap(ValueX7.wrap(a) + ValueX7.wrap(b)), a + b);
+    }
+
+    function test_Sub(ValueX7 _a, ValueX7 _b) external pure {
+        // it returns the difference of two ValueX7 values
+
+        uint256 a = ValueX7.unwrap(_a);
+        uint256 b = bound(ValueX7.unwrap(_b), 0, a);
+
+        assertEq(ValueX7.unwrap(ValueX7.wrap(a) - ValueX7.wrap(b)), a - b);
+    }
+
+    function test_GreaterThanOrEqual(ValueX7 _a, ValueX7 _b) external pure {
+        // it compares the unwrapped values
+
+        uint256 a = ValueX7.unwrap(_a);
+        uint256 b = ValueX7.unwrap(_b);
+
+        assertEq(ValueX7.wrap(a) >= ValueX7.wrap(b), a >= b);
+    }
+}

--- a/test/btt/libraries/valueX7Lib/operators.tree
+++ b/test/btt/libraries/valueX7Lib/operators.tree
@@ -1,0 +1,7 @@
+ValueX7OperatorsTest
+├── add
+│   └── it returns the sum of two ValueX7 values
+├── sub
+│   └── it returns the difference of two ValueX7 values
+└── greater than or equal
+    └── it compares the unwrapped values


### PR DESCRIPTION
## OZ-N01 — Use ValueX7 operators

### Issue
`ValueX7` arithmetic and comparisons were written using verbose named library calls (`.add`, `.sub`, `ValueX7.unwrap(a) >= ValueX7.unwrap(b)`), reducing readability.

### Fix
Bind operator overloads on the `ValueX7` type — `add as +`, `sub as -`, `gte as >=` — and add a `gte` helper. Call sites in `AuctionStorage` and `ContinuousClearingAuction` now use native `+`, `-`, and `>=`. The unused `FixedPointMathLib` import is dropped from `ValueX7Lib`. Readability refactor only — no behavioral change.

### Tests
Added BTT coverage for the `ValueX7` operators in `valueX7Lib/operators.t.sol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)