### PR TITLE
OZ-N02: Remove validation hook supportsMode

### DIFF
--- a/src/periphery/validationHooks/ValidationHookIntrospection.sol
+++ b/src/periphery/validationHooks/ValidationHookIntrospection.sol
@@ -7,12 +7,8 @@ import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 interface IValidationHookIntrospection is IValidationHook, IERC165 {}
 
 /// @notice Base contract for validation hooks supporting basic introspection
-/// @dev Offchain interfaces and integrators should query `supportsInterface` to fuzz what types of validation are run by the hook
+/// @dev Offchain interfaces and integrators should query `supportsInterface` to identify supported hook interfaces
 abstract contract ValidationHookIntrospection is IValidationHookIntrospection {
-    /// @notice Returns true if the mode is supported
-    /// @dev Modes are arbitrary bytes32 values that can be used to identify the type of validation being run
-    function supportsMode(bytes32 _mode) public view virtual returns (bool) {}
-
     /// @inheritdoc IERC165
     function supportsInterface(bytes4 _interfaceId) public view virtual returns (bool) {
         return _interfaceId == type(IValidationHook).interfaceId || _interfaceId == type(IERC165).interfaceId;

--- a/test/btt/periphery/validationHooks/validationHookIntrospection.t.sol
+++ b/test/btt/periphery/validationHooks/validationHookIntrospection.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+import {BttBase} from 'btt/BttBase.sol';
+import {IValidationHook} from 'src/interfaces/IValidationHook.sol';
+import {ValidationHookIntrospection} from 'src/periphery/validationHooks/ValidationHookIntrospection.sol';
+
+contract MockValidationHookIntrospection is ValidationHookIntrospection {
+    function validate(uint256, uint128, address, address, bytes calldata) external pure {}
+}
+
+contract ValidationHookIntrospectionTest is BttBase {
+    function test_SupportsInterface() external {
+        // it supports IERC165
+        // it supports IValidationHook
+        // it does not expose supportsMode(bytes32)
+
+        MockValidationHookIntrospection hook = new MockValidationHookIntrospection();
+
+        assertTrue(hook.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(hook.supportsInterface(type(IValidationHook).interfaceId));
+
+        (bool success,) = address(hook).staticcall(abi.encodeWithSignature('supportsMode(bytes32)', bytes32(0)));
+        assertFalse(success);
+    }
+}

--- a/test/btt/periphery/validationHooks/validationHookIntrospection.tree
+++ b/test/btt/periphery/validationHooks/validationHookIntrospection.tree
@@ -1,0 +1,5 @@
+ValidationHookIntrospectionTest
+└── supports interface
+    ├── it supports IERC165
+    ├── it supports IValidationHook
+    └── it does not expose supportsMode(bytes32)


### PR DESCRIPTION
## OZ-N02 — Remove validation hook supportsMode

### Issue
`ValidationHookIntrospection` exposed an empty `supportsMode(bytes32)` stub with no implementation and no callers. The notion of arbitrary `bytes32` "modes" was unused dead surface area that could confuse integrators about how to introspect a hook.

### Fix
Remove the `supportsMode` function entirely. Introspection now relies solely on `supportsInterface` (ERC-165), and the contract NatSpec is updated to direct offchain consumers to query `supportsInterface` to identify supported hook interfaces.

### Tests
Added BTT coverage in `validationHookIntrospection.t.sol` for the introspection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)