### PR TITLE
OZ-N03: Hide duplicate protocol fee getter

### DIFF
--- a/src/ContinuousClearingAuctionFactory.sol
+++ b/src/ContinuousClearingAuctionFactory.sol
@@ -15,7 +15,7 @@ import {ActionConstants} from 'v4-periphery/src/libraries/ActionConstants.sol';
 /// @custom:security-contact security@uniswap.org
 contract ContinuousClearingAuctionFactory is IContinuousClearingAuctionFactory {
     /// @notice The protocol fee controller to use for all created auctions
-    IProtocolFeeController public immutable PROTOCOL_FEE_CONTROLLER;
+    IProtocolFeeController internal immutable PROTOCOL_FEE_CONTROLLER;
 
     constructor(address _protocolFeeController) {
         PROTOCOL_FEE_CONTROLLER = IProtocolFeeController(_protocolFeeController);

--- a/test/btt/auctionFactory/protocolFeeController.t.sol
+++ b/test/btt/auctionFactory/protocolFeeController.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import {BttBase} from '../BttBase.sol';
+
+import {ContinuousClearingAuctionFactory} from 'src/ContinuousClearingAuctionFactory.sol';
+
+contract ProtocolFeeControllerTest is BttBase {
+    function test_WhenProtocolFeeControllerIsSetAtConstruction(address _protocolFeeController) external {
+        // it exposes the controller through protocolFeeController()
+        // it does not expose a duplicate PROTOCOL_FEE_CONTROLLER() getter
+
+        ContinuousClearingAuctionFactory factory = new ContinuousClearingAuctionFactory(_protocolFeeController);
+
+        assertEq(address(factory.protocolFeeController()), _protocolFeeController);
+
+        (bool success,) = address(factory).staticcall(abi.encodeWithSignature('PROTOCOL_FEE_CONTROLLER()'));
+        assertFalse(success);
+    }
+}

--- a/test/btt/auctionFactory/protocolFeeController.tree
+++ b/test/btt/auctionFactory/protocolFeeController.tree
@@ -1,0 +1,4 @@
+ProtocolFeeControllerTest
+└── when protocol fee controller is set at construction
+    ├── it exposes the controller through protocolFeeController()
+    └── it does not expose a duplicate PROTOCOL_FEE_CONTROLLER() getter


### PR DESCRIPTION
## OZ-N03 — Hide duplicate protocol fee getter

### Issue
`ContinuousClearingAuctionFactory.PROTOCOL_FEE_CONTROLLER` was declared `public immutable`, generating an auto getter that duplicated the protocol fee controller accessor already exposed through the interface.

### Fix
Change the visibility of `PROTOCOL_FEE_CONTROLLER` from `public` to `internal`, removing the redundant auto-generated getter while keeping the value available internally.

### Tests
Added BTT coverage in `auctionFactory/protocolFeeController.t.sol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)