### PR TITLE
OZ-N04: Clarify Q96 price naming

### DIFF
--- a/src/AuctionStorage.sol
+++ b/src/AuctionStorage.sol
@@ -48,7 +48,7 @@ abstract contract AuctionStorage is IAuctionStorage {
     uint256 internal $sumCurrencyDemandAboveClearingQ96;
     /// @notice The most up to date clearing price, set on each call to `checkpoint`
     /// @dev This can be incremented manually by calling `forceIterateOverTicks`
-    uint256 internal $clearingPrice;
+    uint256 internal $clearingPriceQ96;
     /// @notice Whether TOTAL_SUPPLY has been received
     bool internal $_tokensReceived;
 

--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -56,7 +56,7 @@ contract ContinuousClearingAuction is
     using PriceLib for *;
     using DemandLib for uint256;
 
-    /// @notice The maximum price which a bid can be submitted at
+    /// @notice The maximum Q96 price which a bid can be submitted at
     /// @dev Set during construction using MaxBidPriceLib.maxBidPrice() based on TOTAL_SUPPLY
     uint256 public immutable MAX_BID_PRICE;
     /// @notice An optional hook to be called before a bid is registered
@@ -92,8 +92,8 @@ contract ContinuousClearingAuction is
             );
         }
 
-        $clearingPrice = FLOOR_PRICE;
-        emit ClearingPriceUpdated(_getBlockNumberish(), $clearingPrice);
+        $clearingPriceQ96 = FLOOR_PRICE_Q96;
+        emit ClearingPriceUpdated(_getBlockNumberish(), $clearingPriceQ96);
     }
 
     /// @notice Modifier for functions which can only be called after the auction is started and the tokens have been received
@@ -143,7 +143,7 @@ contract ContinuousClearingAuction is
             ProtocolFeeLib.getProtocolFeeAmount(PROTOCOL_FEE_CONTROLLER, Currency.unwrap(CURRENCY), currencyRaised);
 
         return LBPInitializationParams({
-            initialPriceX96: $clearingPrice,
+            initialPriceX96: $clearingPriceQ96,
             tokensSold: totalCleared(),
             currencyRaised: currencyRaised - protocolFeeAmount
         });
@@ -156,7 +156,7 @@ contract ContinuousClearingAuction is
 
     /// @inheritdoc IContinuousClearingAuction
     function clearingPrice() external view returns (uint256) {
-        return $clearingPrice;
+        return $clearingPriceQ96;
     }
 
     /// @inheritdoc IContinuousClearingAuction
@@ -171,20 +171,20 @@ contract ContinuousClearingAuction is
     }
 
     /// @notice Iterate to find the tick where the total demand at and above it is strictly less than the remaining supply in the auction
-    /// @dev If the loop reaches the highest tick in the book, `nextActiveTickPrice` will be set to MAX_TICK_PTR
-    /// @param _untilTickPrice The tick price to iterate until
-    /// @return The new clearing price
-    function _iterateOverTicksAndFindClearingPrice(uint256 _untilTickPrice, uint24 _cumulativeMps)
+    /// @dev If the loop reaches the highest tick in the book, `$nextActiveTickPriceQ96` will be set to MAX_TICK_PTR
+    /// @param _untilTickPriceQ96 The Q96 tick price to iterate until
+    /// @return The new Q96 clearing price
+    function _iterateOverTicksAndFindClearingPrice(uint256 _untilTickPriceQ96, uint24 _cumulativeMps)
         internal
         returns (uint256)
     {
         // The new clearing price can never be lower than the current clearing price
-        uint256 minimumClearingPrice = $clearingPrice;
+        uint256 minimumClearingPriceQ96 = $clearingPriceQ96;
 
         // Place state variables on the stack to save gas
         bool updateStateVariables;
         uint256 demandAboveClearingQ96 = $sumCurrencyDemandAboveClearingQ96;
-        uint256 nextActiveTickPrice_ = $nextActiveTickPrice;
+        uint256 nextActiveTickPriceQ96 = $nextActiveTickPriceQ96;
 
         uint256 remainingMps = ConstantsLib.MPS - _cumulativeMps;
         // Unwrap as we defer dividing by 1e7 by moving it to the LHS as multiplication
@@ -193,43 +193,43 @@ contract ContinuousClearingAuction is
         // Note: it is possible that because of rounding, remainingSupply can be zero even though
         // the auction schedule is not fully completed (remainingMps > 0). The correct treatment
         // for this case is to NOT advance the clearing price (since we cannot sell any more tokens)
-        if (remainingSupplyQ96X7_ == 0 || remainingMps == 0) return minimumClearingPrice;
+        if (remainingSupplyQ96X7_ == 0 || remainingMps == 0) return minimumClearingPriceQ96;
 
-        uint256 clearingPrice_ = demandAboveClearingQ96.toPriceCeiling(remainingSupplyQ96X7_, remainingMps);
+        uint256 clearingPriceQ96 = demandAboveClearingQ96.toPriceCeiling(remainingSupplyQ96X7_, remainingMps);
         while (
             // Loop while demand above the last clearing price >= required demand at the next active tick price
             // See `DemandLib.canClearSupplyAtPrice()` for more details
-            (nextActiveTickPrice_ != _untilTickPrice
+            (nextActiveTickPriceQ96 != _untilTickPriceQ96
                     && demandAboveClearingQ96.canClearSupplyAtPrice(
-                        remainingSupplyQ96X7_, nextActiveTickPrice_, remainingMps
+                        remainingSupplyQ96X7_, nextActiveTickPriceQ96, remainingMps
                     ))
-                // If rounding up the demand above clearing equals the `nextActiveTickPrice`, we need to keep iterating over ticks
-                // to ensure that the `nextActiveTickPrice` is always the next initialized tick strictly above the clearing price
-                || clearingPrice_ == nextActiveTickPrice_
+                // If rounding up the demand above clearing equals `nextActiveTickPriceQ96`, keep iterating over ticks
+                // to ensure that `nextActiveTickPriceQ96` is always the next initialized tick strictly above the clearing price
+                || clearingPriceQ96 == nextActiveTickPriceQ96
         ) {
-            Tick storage $nextActiveTick = _getTick(nextActiveTickPrice_);
+            Tick storage $nextActiveTick = _getTick(nextActiveTickPriceQ96);
             // Subtract the demand at the current nextActiveTick from the total demand
             demandAboveClearingQ96 -= $nextActiveTick.currencyDemandQ96;
             // Save the previous next active tick price
-            minimumClearingPrice = nextActiveTickPrice_;
+            minimumClearingPriceQ96 = nextActiveTickPriceQ96;
             // Advance to the next tick
-            nextActiveTickPrice_ = $nextActiveTick.next;
-            clearingPrice_ = demandAboveClearingQ96.toPriceCeiling(remainingSupplyQ96X7_, remainingMps);
+            nextActiveTickPriceQ96 = $nextActiveTick.next;
+            clearingPriceQ96 = demandAboveClearingQ96.toPriceCeiling(remainingSupplyQ96X7_, remainingMps);
             updateStateVariables = true;
         }
         // Set the values into storage if we found a new next active tick price
         if (updateStateVariables) {
             $sumCurrencyDemandAboveClearingQ96 = demandAboveClearingQ96;
-            $nextActiveTickPrice = nextActiveTickPrice_;
-            emit NextActiveTickUpdated(nextActiveTickPrice_);
+            $nextActiveTickPriceQ96 = nextActiveTickPriceQ96;
+            emit NextActiveTickUpdated(nextActiveTickPriceQ96);
         }
 
         // The auction had sufficient demand at the last iterated tick so the minimum clearing price is the lower bound
-        if (clearingPrice_ < minimumClearingPrice) {
-            return minimumClearingPrice;
+        if (clearingPriceQ96 < minimumClearingPriceQ96) {
+            return minimumClearingPriceQ96;
         }
         // Otherwise, return the calculated clearing price
-        return clearingPrice_;
+        return clearingPriceQ96;
     }
 
     /// @notice Internal function for checkpointing at a specific block number
@@ -249,16 +249,16 @@ contract ContinuousClearingAuction is
         if (_checkpoint.remainingMpsInAuction() > 0) {
             // Iterate over all ticks until MAX_TICK_PTR to find the clearing price
             // This can revert with out of gas if there are a large number of ticks
-            uint256 newClearingPrice = _iterateOverTicksAndFindClearingPrice(MAX_TICK_PTR, _checkpoint.cumulativeMps);
+            uint256 newClearingPriceQ96 = _iterateOverTicksAndFindClearingPrice(MAX_TICK_PTR, _checkpoint.cumulativeMps);
             // checkpoint has the stale clearing price
-            if (newClearingPrice != _checkpoint.clearingPrice) {
+            if (newClearingPriceQ96 != _checkpoint.clearingPrice) {
                 // Set the new clearing price
-                _checkpoint.clearingPrice = newClearingPrice;
+                _checkpoint.clearingPrice = newClearingPriceQ96;
                 // Reset the currencyRaisedAtClearingPrice to zero since the clearing price has changed
                 _checkpoint.currencyRaisedAtClearingPriceQ96X7 = ValueX7.wrap(0);
                 // Write the new clearing price to storage
-                $clearingPrice = newClearingPrice;
-                emit ClearingPriceUpdated(_blockNumber, newClearingPrice);
+                $clearingPriceQ96 = newClearingPriceQ96;
+                emit ClearingPriceUpdated(_blockNumber, newClearingPriceQ96);
             }
         }
 
@@ -288,7 +288,7 @@ contract ContinuousClearingAuction is
                 ValueX7 currencyRaisedDeltaQ96X7 = ValueX7.wrap(sumAboveClearingPriceQ96 * deltaMps);
 
                 // However, we need to find currency raised at clearing price if there are bids there
-                if (clearingPriceQ96 % TICK_SPACING == 0) {
+                if (clearingPriceQ96 % TICK_SPACING_Q96 == 0) {
                     uint256 demandAtClearingPriceQ96 = _getTick(clearingPriceQ96).currencyDemandQ96;
                     if (demandAtClearingPriceQ96 > 0) {
                         ValueX7 currencyRaisedAtClearingQ96X7 = DemandLib.currencyRaisedAtPrice(
@@ -338,22 +338,22 @@ contract ContinuousClearingAuction is
     }
 
     /// @notice Internal function for bid submission
-    /// @dev Validates `maxPrice`, calls the validation hook (if set) and updates global state variables
-    ///      For gas efficiency, `prevTickPrice` should be the price of the tick immediately before `maxPrice`.
+    /// @dev Validates `maxPriceQ96`, calls the validation hook (if set) and updates global state variables.
+    ///      For gas efficiency, `prevTickPriceQ96` should be the Q96 price of the tick immediately before `maxPriceQ96`.
     /// @dev Implementing functions must check that the actual value `amount` is received by the contract
     /// @return bidId The id of the created bid
     function _submitBid(
-        uint256 _maxPrice,
+        uint256 _maxPriceQ96,
         uint128 _amount,
         address _owner,
-        uint256 _prevTickPrice,
+        uint256 _prevTickPriceQ96,
         bytes calldata _hookData
     ) internal returns (uint256 bidId) {
-        // Reject bids which would cause TOTAL_SUPPLY * maxPrice to overflow a uint256
-        if (_maxPrice > MAX_BID_PRICE) revert InvalidBidPriceTooHigh(_maxPrice, MAX_BID_PRICE);
+        // Reject bids which would cause TOTAL_SUPPLY * maxPriceQ96 to overflow a uint256
+        if (_maxPriceQ96 > MAX_BID_PRICE) revert InvalidBidPriceTooHigh(_maxPriceQ96, MAX_BID_PRICE);
 
         // Call the validation hook and bubble up the revert reason if it reverts
-        VALIDATION_HOOK.handleValidate(_maxPrice, _amount, _owner, msg.sender, _hookData);
+        VALIDATION_HOOK.handleValidate(_maxPriceQ96, _amount, _owner, msg.sender, _hookData);
 
         // Get the latest checkpoint before validating the bid
         uint64 currentBlockNumberIsh = uint64(_getBlockNumberish());
@@ -363,21 +363,21 @@ contract ContinuousClearingAuction is
             revert AuctionSoldOut();
         }
         // We don't allow bids to be submitted at or below the clearing price
-        if (_maxPrice <= $clearingPrice) revert BidMustBeAboveClearingPrice();
+        if (_maxPriceQ96 <= $clearingPriceQ96) revert BidMustBeAboveClearingPrice();
 
         // Initialize the tick if needed. This will no-op if the tick is already initialized.
-        _initializeTickIfNeeded(_prevTickPrice, _maxPrice);
+        _initializeTickIfNeeded(_prevTickPriceQ96, _maxPriceQ96);
 
         Bid memory bid;
         uint256 amountQ96 = uint256(_amount) << FixedPoint96.RESOLUTION;
-        (bid, bidId) = _createBid(currentBlockNumberIsh, amountQ96, _owner, _maxPrice, _checkpoint.cumulativeMps);
+        (bid, bidId) = _createBid(currentBlockNumberIsh, amountQ96, _owner, _maxPriceQ96, _checkpoint.cumulativeMps);
 
         // Scale the amount according to the rest of the supply schedule, accounting for past blocks
         // This is only used in demand related internal calculations
         uint256 bidEffectiveAmountQ96 = bid.toEffectiveAmount();
 
         // Update the tick demand with the bid's scaled amount
-        _updateTickDemand(_maxPrice, bidEffectiveAmountQ96);
+        _updateTickDemand(_maxPriceQ96, bidEffectiveAmountQ96);
         // Update the global sum of currency demand above the clearing price tracker
         // Per the validation checks above this bid must be above the clearing price
         $sumCurrencyDemandAboveClearingQ96 += bidEffectiveAmountQ96;
@@ -388,7 +388,7 @@ contract ContinuousClearingAuction is
             revert InvalidBidUnableToClear();
         }
 
-        emit BidSubmitted(bidId, _owner, _maxPrice, _amount);
+        emit BidSubmitted(bidId, _owner, _maxPriceQ96, _amount);
     }
 
     /// @notice Internal function for processing the exit of a bid
@@ -428,35 +428,40 @@ contract ContinuousClearingAuction is
 
     /// @notice Manually iterate over ticks to update the clearing price
     /// @dev This is used to prevent DoS attacks which initialize a large number of ticks
-    /// @param _untilTickPrice The tick price to iterate until
-    function forceIterateOverTicks(uint256 _untilTickPrice) external onlyActiveAuction nonReentrant returns (uint256) {
-        if (_untilTickPrice != MAX_TICK_PTR) {
-            // Ensure that the price is at a tick boundary
-            Tick storage $tick = _getTick(_untilTickPrice);
+    /// @param _untilTickPriceQ96 The Q96 tick price to iterate until
+    function forceIterateOverTicks(uint256 _untilTickPriceQ96)
+        external
+        onlyActiveAuction
+        nonReentrant
+        returns (uint256)
+    {
+        if (_untilTickPriceQ96 != MAX_TICK_PTR) {
+            // Ensure that the Q96 price is at a tick boundary
+            Tick storage $tick = _getTick(_untilTickPriceQ96);
             // The tick must be initialized otherwise it will be an infinite loop
             if ($tick.next == 0) revert TickNotInitialized();
             // The untilTickPrice must be greater than the current next active tick price
-            if (_untilTickPrice <= $nextActiveTickPrice) {
-                revert TickHintMustBeGreaterThanNextActiveTickPrice(_untilTickPrice, $nextActiveTickPrice);
+            if (_untilTickPriceQ96 <= $nextActiveTickPriceQ96) {
+                revert TickHintMustBeGreaterThanNextActiveTickPrice(_untilTickPriceQ96, $nextActiveTickPriceQ96);
             }
         }
-        uint256 newClearingPrice =
-            _iterateOverTicksAndFindClearingPrice(_untilTickPrice, latestCheckpoint().cumulativeMps);
+        uint256 newClearingPriceQ96 =
+            _iterateOverTicksAndFindClearingPrice(_untilTickPriceQ96, latestCheckpoint().cumulativeMps);
         // Update the clearing price in storage if it has changed
-        if (newClearingPrice != $clearingPrice) {
-            $clearingPrice = newClearingPrice;
-            emit ClearingPriceUpdated(_getBlockNumberish(), newClearingPrice);
+        if (newClearingPriceQ96 != $clearingPriceQ96) {
+            $clearingPriceQ96 = newClearingPriceQ96;
+            emit ClearingPriceUpdated(_getBlockNumberish(), newClearingPriceQ96);
         }
-        return newClearingPrice;
+        return newClearingPriceQ96;
     }
 
     /// @inheritdoc IContinuousClearingAuction
     /// @dev Bids can be submitted anytime between the startBlock and the endBlock.
     function submitBid(
-        uint256 _maxPrice,
+        uint256 _maxPriceQ96,
         uint128 _amount,
         address _owner,
-        uint256 _prevTickPrice,
+        uint256 _prevTickPriceQ96,
         bytes calldata _hookData
     ) public payable onlyActiveAuction nonReentrant returns (uint256) {
         // Bids cannot be submitted at the endBlock or after
@@ -469,17 +474,17 @@ contract ContinuousClearingAuction is
             if (msg.value != 0) revert CurrencyIsNotNative();
             SafeTransferLib.permit2TransferFrom(Currency.unwrap(CURRENCY), msg.sender, address(this), _amount);
         }
-        return _submitBid(_maxPrice, _amount, _owner, _prevTickPrice, _hookData);
+        return _submitBid(_maxPriceQ96, _amount, _owner, _prevTickPriceQ96, _hookData);
     }
 
     /// @inheritdoc IContinuousClearingAuction
     /// @dev The call to `submitBid` checks `onlyActiveAuction` so it's not required on this function
-    function submitBid(uint256 _maxPrice, uint128 _amount, address _owner, bytes calldata _hookData)
+    function submitBid(uint256 _maxPriceQ96, uint128 _amount, address _owner, bytes calldata _hookData)
         external
         payable
         returns (uint256)
     {
-        return submitBid(_maxPrice, _amount, _owner, FLOOR_PRICE, _hookData);
+        return submitBid(_maxPriceQ96, _amount, _owner, FLOOR_PRICE_Q96, _hookData);
     }
 
     /// @inheritdoc IContinuousClearingAuction
@@ -697,7 +702,7 @@ contract ContinuousClearingAuction is
 
     /// @inheritdoc IContinuousClearingAuction
     function requiredDemandQ96AtNextActiveTick() public view returns (uint256) {
-        return requiredDemandQ96($nextActiveTickPrice);
+        return requiredDemandQ96($nextActiveTickPriceQ96);
     }
 
     // Immutable getters

--- a/src/TickStorage.sol
+++ b/src/TickStorage.sol
@@ -7,87 +7,87 @@ import {ConstantsLib} from './libraries/ConstantsLib.sol';
 /// @title TickStorage
 /// @notice Abstract contract for handling tick storage
 abstract contract TickStorage is ITickStorage {
-    /// @notice Mapping of price levels to tick data
-    mapping(uint256 price => Tick) private $_ticks;
+    /// @notice Mapping of Q96 price levels to tick data
+    mapping(uint256 priceQ96 => Tick) private $_ticks;
 
-    /// @notice The price of the next initialized tick above the clearing price
-    /// @dev This will be equal to the clearingPrice if no ticks have been initialized yet
-    uint256 internal $nextActiveTickPrice;
-    /// @notice The floor price of the auction
-    uint256 internal immutable FLOOR_PRICE;
-    /// @notice The tick spacing of the auction - bids must be placed at discrete tick intervals
-    uint256 internal immutable TICK_SPACING;
+    /// @notice The Q96 price of the next initialized tick above the clearing price
+    /// @dev This will be MAX_TICK_PTR if there are no initialized ticks above the clearing price
+    uint256 internal $nextActiveTickPriceQ96;
+    /// @notice The Q96 floor price of the auction
+    uint256 internal immutable FLOOR_PRICE_Q96;
+    /// @notice The Q96 tick spacing of the auction - bids must be placed at discrete tick intervals
+    uint256 internal immutable TICK_SPACING_Q96;
 
     /// @notice Sentinel value for the next pointer of the highest tick in the book
     uint256 public constant MAX_TICK_PTR = type(uint256).max;
 
-    constructor(uint256 _tickSpacing, uint256 _floorPrice) {
-        if (_tickSpacing < ConstantsLib.MIN_TICK_SPACING) revert TickSpacingTooSmall();
-        TICK_SPACING = _tickSpacing;
-        if (_floorPrice == 0) revert FloorPriceIsZero();
-        if (_floorPrice < ConstantsLib.MIN_FLOOR_PRICE) revert FloorPriceTooLow();
-        FLOOR_PRICE = _floorPrice;
-        // Initialize the floor price as the first tick
+    constructor(uint256 _tickSpacingQ96, uint256 _floorPriceQ96) {
+        if (_tickSpacingQ96 < ConstantsLib.MIN_TICK_SPACING) revert TickSpacingTooSmall();
+        TICK_SPACING_Q96 = _tickSpacingQ96;
+        if (_floorPriceQ96 == 0) revert FloorPriceIsZero();
+        if (_floorPriceQ96 < ConstantsLib.MIN_FLOOR_PRICE) revert FloorPriceTooLow();
+        FLOOR_PRICE_Q96 = _floorPriceQ96;
+        // Initialize the Q96 floor price as the first tick
         // _getTick will validate that it is also at a tick boundary
-        _getTick(FLOOR_PRICE).next = MAX_TICK_PTR;
-        $nextActiveTickPrice = MAX_TICK_PTR;
+        _getTick(FLOOR_PRICE_Q96).next = MAX_TICK_PTR;
+        $nextActiveTickPriceQ96 = MAX_TICK_PTR;
         emit NextActiveTickUpdated(MAX_TICK_PTR);
-        emit TickInitialized(FLOOR_PRICE);
+        emit TickInitialized(FLOOR_PRICE_Q96);
     }
 
-    /// @notice Internal function to get a tick at a price
+    /// @notice Internal function to get a tick at a Q96 price
     /// @dev The returned tick is not guaranteed to be initialized
-    function _getTick(uint256 price) internal view returns (Tick storage) {
-        // Validate `price` is at a boundary designated by the tick spacing
-        if (price % TICK_SPACING != 0) revert TickPriceNotAtBoundary();
-        return $_ticks[price];
+    function _getTick(uint256 priceQ96) internal view returns (Tick storage) {
+        // Validate `priceQ96` is at a boundary designated by the tick spacing
+        if (priceQ96 % TICK_SPACING_Q96 != 0) revert TickPriceNotAtBoundary();
+        return $_ticks[priceQ96];
     }
 
-    /// @notice Initialize a tick at `price` if it does not exist already
-    /// @dev `prevPrice` MUST be the price of an initialized tick before the new price.
-    ///      Ideally, it is the price of the tick immediately preceding the desired price. If not,
-    ///      we will iterate through the ticks until we find the next price which requires more gas.
-    ///      If `price` is < `nextActiveTickPrice`, then `price` will be set as the nextActiveTickPrice
-    /// @param prevPrice The price of the previous tick
-    /// @param price The price of the tick
-    function _initializeTickIfNeeded(uint256 prevPrice, uint256 price) internal {
-        if (price == MAX_TICK_PTR) revert InvalidTickPrice();
-        // _getTick will validate that `price` is at a boundary designated by the tick spacing
-        Tick storage $newTick = _getTick(price);
+    /// @notice Initialize a tick at `priceQ96` if it does not exist already
+    /// @dev `prevPriceQ96` MUST be the Q96 price of an initialized tick before the new Q96 price.
+    ///      Ideally, it is the Q96 price of the tick immediately preceding the desired Q96 price. If not,
+    ///      we will iterate through the ticks until we find the next Q96 price, which requires more gas.
+    ///      If `priceQ96` is < `$nextActiveTickPriceQ96`, then `priceQ96` will become the next active tick price.
+    /// @param prevPriceQ96 The Q96 price of the previous tick
+    /// @param priceQ96 The Q96 price of the tick
+    function _initializeTickIfNeeded(uint256 prevPriceQ96, uint256 priceQ96) internal {
+        if (priceQ96 == MAX_TICK_PTR) revert InvalidTickPrice();
+        // _getTick will validate that `priceQ96` is at a boundary designated by the tick spacing
+        Tick storage $newTick = _getTick(priceQ96);
         // Early return if the tick is already initialized
         if ($newTick.next != 0) return;
         // Otherwise, we need to iterate through the linked list to find the correct position for the new tick
-        // Require that `prevPrice` is less than `price` since we can only iterate forward
-        if (prevPrice >= price) revert TickPreviousPriceInvalid();
-        uint256 nextPrice = _getTick(prevPrice).next;
-        // Revert if the next price is 0 as that means the `prevPrice` hint was not an initialized tick
-        if (nextPrice == 0) revert TickPreviousPriceInvalid();
-        // Move the `prevPrice` pointer up until its next pointer is a tick greater than or equal to `price`
-        // If `price` would be the highest tick in the list, this will iterate until `nextPrice` == MAX_TICK_PTR,
+        // Require that `prevPriceQ96` is less than `priceQ96` since we can only iterate forward
+        if (prevPriceQ96 >= priceQ96) revert TickPreviousPriceInvalid();
+        uint256 nextPriceQ96 = _getTick(prevPriceQ96).next;
+        // Revert if the next Q96 price is 0 as that means the `prevPriceQ96` hint was not an initialized tick
+        if (nextPriceQ96 == 0) revert TickPreviousPriceInvalid();
+        // Move the `prevPriceQ96` pointer up until its next pointer is a tick greater than or equal to `priceQ96`
+        // If `priceQ96` would be the highest tick in the list, this will iterate until `nextPriceQ96` == MAX_TICK_PTR,
         // which will end the loop since we don't allow for ticks to be initialized at MAX_TICK_PTR.
-        // Iterating to find the tick right before `price` ensures that it is correctly positioned in the linked list.
-        while (nextPrice < price) {
-            prevPrice = nextPrice;
-            nextPrice = _getTick(nextPrice).next;
+        // Iterating to find the tick right before `priceQ96` ensures that it is correctly positioned in the linked list.
+        while (nextPriceQ96 < priceQ96) {
+            prevPriceQ96 = nextPriceQ96;
+            nextPriceQ96 = _getTick(nextPriceQ96).next;
         }
         // Update linked list pointers
-        $newTick.next = nextPrice;
-        _getTick(prevPrice).next = price;
+        $newTick.next = nextPriceQ96;
+        _getTick(prevPriceQ96).next = priceQ96;
         // If the next tick is the nextActiveTick, update nextActiveTick to the new tick
-        // In the base case, where next == 0 and nextActiveTickPrice == 0, this will set nextActiveTickPrice to price
-        if (nextPrice == $nextActiveTickPrice) {
-            $nextActiveTickPrice = price;
-            emit NextActiveTickUpdated(price);
+        // If the inserted tick precedes the current next active tick, make it the next active tick.
+        if (nextPriceQ96 == $nextActiveTickPriceQ96) {
+            $nextActiveTickPriceQ96 = priceQ96;
+            emit NextActiveTickUpdated(priceQ96);
         }
 
-        emit TickInitialized(price);
+        emit TickInitialized(priceQ96);
     }
 
     /// @notice Internal function to add demand to a tick
-    /// @param price The price of the tick
+    /// @param priceQ96 The Q96 price of the tick
     /// @param currencyDemandQ96 The demand to add
-    function _updateTickDemand(uint256 price, uint256 currencyDemandQ96) internal {
-        Tick storage $tick = _getTick(price);
+    function _updateTickDemand(uint256 priceQ96, uint256 currencyDemandQ96) internal {
+        Tick storage $tick = _getTick(priceQ96);
         if ($tick.next == 0) revert CannotUpdateUninitializedTick();
         $tick.currencyDemandQ96 += currencyDemandQ96;
     }
@@ -95,21 +95,21 @@ abstract contract TickStorage is ITickStorage {
     // Getters
     /// @inheritdoc ITickStorage
     function floorPrice() external view returns (uint256) {
-        return FLOOR_PRICE;
+        return FLOOR_PRICE_Q96;
     }
 
     /// @inheritdoc ITickStorage
     function tickSpacing() external view returns (uint256) {
-        return TICK_SPACING;
+        return TICK_SPACING_Q96;
     }
 
     /// @inheritdoc ITickStorage
     function nextActiveTickPrice() external view returns (uint256) {
-        return $nextActiveTickPrice;
+        return $nextActiveTickPriceQ96;
     }
 
     /// @inheritdoc ITickStorage
-    function ticks(uint256 price) external view returns (Tick memory) {
-        return _getTick(price);
+    function ticks(uint256 priceQ96) external view returns (Tick memory) {
+        return _getTick(priceQ96);
     }
 }

--- a/src/interfaces/IContinuousClearingAuction.sol
+++ b/src/interfaces/IContinuousClearingAuction.sol
@@ -20,9 +20,9 @@ struct AuctionParameters {
     uint64 startBlock; // Block which the first step starts
     uint64 endBlock; // When the auction finishes
     uint64 claimBlock; // Block when the auction can claimed
-    uint256 tickSpacing; // Fixed granularity for prices
+    uint256 tickSpacing; // Fixed Q96 granularity for prices
     address validationHook; // Optional hook called before a bid
-    uint256 floorPrice; // Starting floor price for the auction
+    uint256 floorPrice; // Starting Q96 floor price for the auction
     uint128 requiredCurrencyRaised; // Amount of currency required to be raised for the auction to graduate
     bytes auctionStepsData; // Packed bytes describing token issuance schedule
 }
@@ -44,12 +44,12 @@ interface IContinuousClearingAuction is
     error InvalidAmount();
     /// @notice Error thrown when the bid owner is the zero address
     error BidOwnerCannotBeZeroAddress();
-    /// @notice Error thrown when the bid price is below the clearing price
+    /// @notice Error thrown when the bid Q96 price is below the clearing price
     error BidMustBeAboveClearingPrice();
-    /// @notice Error thrown when the bid price is too high given the auction's total supply
-    /// @param maxPrice The price of the bid
-    /// @param maxBidPrice The max price allowed for a bid
-    error InvalidBidPriceTooHigh(uint256 maxPrice, uint256 maxBidPrice);
+    /// @notice Error thrown when the bid Q96 price is too high given the auction's total supply
+    /// @param maxPriceQ96 The Q96 price of the bid
+    /// @param maxBidPriceQ96 The max Q96 price allowed for a bid
+    error InvalidBidPriceTooHigh(uint256 maxPriceQ96, uint256 maxBidPriceQ96);
     /// @notice Error thrown when the bid amount is too small
     error BidAmountTooSmall();
     /// @notice Error thrown when msg.value is non zero when currency is not ETH
@@ -59,12 +59,12 @@ interface IContinuousClearingAuction is
     /// @notice Error thrown when the tokens required for the auction have not been received
     error TokensNotReceived();
     /// @notice Error thrown when the floor price plus tick spacing is greater than the maximum bid price
-    error FloorPriceAndTickSpacingGreaterThanMaxBidPrice(uint256 nextTick, uint256 maxBidPrice);
+    error FloorPriceAndTickSpacingGreaterThanMaxBidPrice(uint256 nextTickQ96, uint256 maxBidPriceQ96);
     /// @notice Error thrown when the floor price plus tick spacing would overflow a uint256
     error FloorPriceAndTickSpacingTooLarge();
     /// @notice Error thrown when the bid has already been exited
     error BidAlreadyExited();
-    /// @notice Error thrown when the bid is higher than the clearing price
+    /// @notice Error thrown when the bid is higher than the clearing Q96 price
     error CannotExitBid();
     /// @notice Error thrown when the bid cannot be partially exited before the end block
     error CannotPartiallyExitBidBeforeEndBlock();
@@ -86,8 +86,8 @@ interface IContinuousClearingAuction is
     error InvalidBidUnableToClear();
     /// @notice Error thrown when the auction has sold the entire total supply of tokens
     error AuctionSoldOut();
-    /// @notice Error thrown when the tick price is not greater than the next active tick price
-    error TickHintMustBeGreaterThanNextActiveTickPrice(uint256 tickPrice, uint256 nextActiveTickPrice);
+    /// @notice Error thrown when the tick Q96 price is not greater than the next active tick Q96 price
+    error TickHintMustBeGreaterThanNextActiveTickPrice(uint256 tickPriceQ96, uint256 nextActiveTickPriceQ96);
 
     /// @notice Emitted when the tokens are received
     /// @param totalSupply The total supply of tokens received
@@ -96,20 +96,20 @@ interface IContinuousClearingAuction is
     /// @notice Emitted when a bid is submitted
     /// @param id The id of the bid
     /// @param owner The owner of the bid
-    /// @param price The price of the bid
+    /// @param priceQ96 The Q96 price of the bid
     /// @param amount The amount of the bid
-    event BidSubmitted(uint256 indexed id, address indexed owner, uint256 price, uint128 amount);
+    event BidSubmitted(uint256 indexed id, address indexed owner, uint256 priceQ96, uint128 amount);
 
     /// @notice Emitted when a new checkpoint is created
     /// @param blockNumber The block number of the checkpoint
-    /// @param clearingPrice The clearing price of the checkpoint
+    /// @param clearingPriceQ96 The Q96 clearing price of the checkpoint
     /// @param cumulativeMps The cumulative percentage of total tokens allocated across all previous steps, represented in ten-millionths of the total supply (1e7 = 100%)
-    event CheckpointUpdated(uint256 blockNumber, uint256 clearingPrice, uint24 cumulativeMps);
+    event CheckpointUpdated(uint256 blockNumber, uint256 clearingPriceQ96, uint24 cumulativeMps);
 
     /// @notice Emitted when the clearing price is updated
     /// @param blockNumber The block number when the clearing price was updated
-    /// @param clearingPrice The new clearing price
-    event ClearingPriceUpdated(uint256 blockNumber, uint256 clearingPrice);
+    /// @param clearingPriceQ96 The new Q96 clearing price
+    event ClearingPriceUpdated(uint256 blockNumber, uint256 clearingPriceQ96);
 
     /// @notice Emitted when a bid is exited
     /// @param bidId The id of the bid
@@ -125,26 +125,29 @@ interface IContinuousClearingAuction is
     event TokensClaimed(uint256 indexed bidId, address indexed owner, uint256 tokensFilled);
 
     /// @notice Submit a new bid
-    /// @param maxPrice The maximum price the bidder is willing to pay
+    /// @param maxPriceQ96 The maximum Q96 price the bidder is willing to pay
     /// @param amount The amount of the bid
     /// @param owner The owner of the bid
-    /// @param prevTickPrice The price of the previous tick
+    /// @param prevTickPriceQ96 The Q96 price of the previous tick
     /// @param hookData Additional data to pass to the hook required for validation
     /// @return bidId The id of the bid
-    function submitBid(uint256 maxPrice, uint128 amount, address owner, uint256 prevTickPrice, bytes calldata hookData)
-        external
-        payable
-        returns (uint256 bidId);
+    function submitBid(
+        uint256 maxPriceQ96,
+        uint128 amount,
+        address owner,
+        uint256 prevTickPriceQ96,
+        bytes calldata hookData
+    ) external payable returns (uint256 bidId);
 
     /// @notice Submit a new bid without specifying the previous tick price
-    /// @dev It is NOT recommended to use this function unless you are sure that `maxPrice` is already initialized
+    /// @dev It is NOT recommended to use this function unless you are sure that `maxPriceQ96` is already initialized
     ///      as this function will iterate through every tick starting from the floor price if it is not.
-    /// @param maxPrice The maximum price the bidder is willing to pay
+    /// @param maxPriceQ96 The maximum Q96 price the bidder is willing to pay
     /// @param amount The amount of the bid
     /// @param owner The owner of the bid
     /// @param hookData Additional data to pass to the hook required for validation
     /// @return bidId The id of the bid
-    function submitBid(uint256 maxPrice, uint128 amount, address owner, bytes calldata hookData)
+    function submitBid(uint256 maxPriceQ96, uint128 amount, address owner, bytes calldata hookData)
         external
         payable
         returns (uint256 bidId);

--- a/src/interfaces/ITickStorage.sol
+++ b/src/interfaces/ITickStorage.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @notice Each tick contains a pointer to the next price in the linked list
-///         and the cumulative currency demand at the tick's price level
+/// @notice Each tick contains a pointer to the next Q96 price in the linked list
+///         and the cumulative currency demand at the tick's Q96 price level
 struct Tick {
     uint256 next;
     uint256 currencyDemandQ96;
@@ -17,13 +17,13 @@ interface ITickStorage {
     error FloorPriceIsZero();
     /// @notice Error thrown when the floor price is below the minimum floor price
     error FloorPriceTooLow();
-    /// @notice Error thrown when the previous price hint is invalid (higher than the new price)
+    /// @notice Error thrown when the previous Q96 price hint is invalid (higher than the new Q96 price)
     error TickPreviousPriceInvalid();
     /// @notice Error thrown when the tick price is not increasing
     error TickPriceNotIncreasing();
     /// @notice Error thrown when the tick is not initialized
     error TickNotInitialized();
-    /// @notice Error thrown when the price is not at a boundary designated by the tick spacing
+    /// @notice Error thrown when the Q96 price is not at a boundary designated by the tick spacing
     error TickPriceNotAtBoundary();
     /// @notice Error thrown when the tick price is invalid
     error InvalidTickPrice();
@@ -31,29 +31,29 @@ interface ITickStorage {
     error CannotUpdateUninitializedTick();
 
     /// @notice Emitted when a tick is initialized
-    /// @param price The price of the tick
-    event TickInitialized(uint256 price);
+    /// @param priceQ96 The Q96 price of the tick
+    event TickInitialized(uint256 priceQ96);
 
     /// @notice Emitted when the nextActiveTick is updated
-    /// @param price The price of the tick
-    event NextActiveTickUpdated(uint256 price);
+    /// @param priceQ96 The Q96 price of the tick
+    event NextActiveTickUpdated(uint256 priceQ96);
 
-    /// @notice The price of the next initialized tick above the clearing price
-    /// @dev This will be equal to the clearingPrice if no ticks have been initialized yet
-    /// @return The price of the next active tick
+    /// @notice The Q96 price of the next initialized tick above the clearing price
+    /// @dev This will be MAX_TICK_PTR if there are no initialized ticks above the clearing price
+    /// @return The Q96 price of the next active tick
     function nextActiveTickPrice() external view returns (uint256);
 
-    /// @notice Get the floor price of the auction
-    /// @return The minimum price for bids
+    /// @notice Get the Q96 floor price of the auction
+    /// @return The minimum Q96 price for bids
     function floorPrice() external view returns (uint256);
 
-    /// @notice Get the tick spacing enforced for bid prices
-    /// @return The tick spacing value
+    /// @notice Get the Q96 tick spacing enforced for bid prices
+    /// @return The Q96 tick spacing value
     function tickSpacing() external view returns (uint256);
 
-    /// @notice Get a tick at a price
+    /// @notice Get a tick at a Q96 price
     /// @dev The returned tick is not guaranteed to be initialized
-    /// @param price The price of the tick, which must be at a boundary designated by the tick spacing
-    /// @return The tick at the given price
-    function ticks(uint256 price) external view returns (Tick memory);
+    /// @param priceQ96 The Q96 price of the tick, which must be at a boundary designated by the tick spacing
+    /// @return The tick at the given Q96 price
+    function ticks(uint256 priceQ96) external view returns (Tick memory);
 }

--- a/test/TickStorage.t.sol
+++ b/test/TickStorage.t.sol
@@ -13,9 +13,9 @@ import {Test} from 'forge-std/Test.sol';
 contract MockTickStorage is TickStorage {
     constructor(uint256 _tickSpacing, uint256 _floorPrice) TickStorage(_tickSpacing, _floorPrice) {}
 
-    /// @notice Set the nextActiveTickPrice, only for testing
-    function setNextActiveTickPrice(uint256 price) external {
-        $nextActiveTickPrice = price;
+    /// @notice Set the nextActiveTickPriceQ96, only for testing
+    function setNextActiveTickPrice(uint256 priceQ96) external {
+        $nextActiveTickPriceQ96 = priceQ96;
     }
 
     function initializeTickIfNeeded(uint256 prevPrice, uint256 price) external {

--- a/test/btt/mocks/MockTickStorage.sol
+++ b/test/btt/mocks/MockTickStorage.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.26;
 import {TickStorage} from 'continuous-clearing-auction/TickStorage.sol';
 
 contract MockTickStorage is TickStorage {
-    constructor(uint256 _tickSpacing, uint256 _floorPrice) TickStorage(_tickSpacing, _floorPrice) {}
+    constructor(uint256 _tickSpacingQ96, uint256 _floorPriceQ96) TickStorage(_tickSpacingQ96, _floorPriceQ96) {}
 
-    function updateTickDemand(uint256 price, uint256 demandQ96) external {
-        super._updateTickDemand(price, demandQ96);
+    function updateTickDemand(uint256 priceQ96, uint256 demandQ96) external {
+        super._updateTickDemand(priceQ96, demandQ96);
     }
 
-    function initializeTickIfNeeded(uint256 prevPrice, uint256 price) external {
-        super._initializeTickIfNeeded(prevPrice, price);
+    function initializeTickIfNeeded(uint256 prevPriceQ96, uint256 priceQ96) external {
+        super._initializeTickIfNeeded(prevPriceQ96, priceQ96);
     }
 }

--- a/test/btt/tickstorage/constructor.t.sol
+++ b/test/btt/tickstorage/constructor.t.sol
@@ -88,9 +88,9 @@ contract ConstructorTest is BttBase {
         whenFloorPriceGT0
         whenFloorPriceGTEMinFloorPrice
     {
-        // it writes FLOOR_PRICE
+        // it writes FLOOR_PRICE_Q96
         // it writes next tick to be MAX_TICK_PTR
-        // it writes nextActiveTickPrice to be MAX_TICK_PTR
+        // it writes nextActiveTickPriceQ96 to be MAX_TICK_PTR
         // it emits {TickInitialized}
         // it emits {NextActiveTickUpdated}
 

--- a/test/btt/tickstorage/constructor.tree
+++ b/test/btt/tickstorage/constructor.tree
@@ -8,8 +8,8 @@ ConstructorTest
         ├── when floor price not perfectly divisible by tick spacing
         │   └── it reverts with {TickPriceNotAtBoundary}
         └── when floor price is perfectly divisible by tick spacing
-            ├── it writes FLOOR_PRICE
+            ├── it writes FLOOR_PRICE_Q96
             ├── it writes next tick to be MAX_TICK_PTR
-            ├── it writes nextActiveTickPrice to be MAX_TICK_PTR
+            ├── it writes nextActiveTickPriceQ96 to be MAX_TICK_PTR
             ├── it emits {TickInitialized}
             └── it emits {NextActiveTickUpdated}

--- a/test/utils/MockAuction.sol
+++ b/test/utils/MockAuction.sol
@@ -44,8 +44,8 @@ contract MockContinuousClearingAuction is ContinuousClearingAuction {
         _initializeTickIfNeeded(prevPrice, price);
     }
 
-    function uncheckedSetNextActiveTickPrice(uint256 price) external {
-        $nextActiveTickPrice = price;
+    function uncheckedSetNextActiveTickPrice(uint256 priceQ96) external {
+        $nextActiveTickPriceQ96 = priceQ96;
     }
 
     /// @notice Update the tick demand


### PR DESCRIPTION
## OZ-N04 — Clarify Q96 price naming

### Issue
Prices throughout the auction and tick storage are stored as Q96 fixed-point values, but variables, parameters, return values, events, and NatSpec referred to them simply as `price`. The lack of a consistent `Q96` suffix made it ambiguous whether a given value was a raw price or a Q96-encoded price.

### Fix
Consistently rename price-related identifiers and documentation to carry the `Q96` suffix (e.g. `price` → `priceQ96`, `TickInitialized(price)` → `TickInitialized(priceQ96)`, floor price / tick spacing / tick getters and their NatSpec). This is a naming/documentation refactor across `ContinuousClearingAuction`, `TickStorage`, `AuctionStorage`, and the related interfaces — no behavioral change.

### Tests
Updated affected tests and mocks (`TickStorage.t.sol`, `MockTickStorage`, `MockAuction`, tickstorage BTT) to the new naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)