### PR TITLE
OZ-N05: Remove unused DemandLib import

### DIFF
--- a/src/libraries/DemandLib.sol
+++ b/src/libraries/DemandLib.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ConstantsLib} from './ConstantsLib.sol';
 import {FixedPoint96} from './FixedPoint96.sol';
 import {PriceLib} from './PriceLib.sol';
 import {ValueX7} from './ValueX7Lib.sol';


### PR DESCRIPTION
## OZ-N05 — Remove unused DemandLib import

### Issue
`DemandLib.sol` imported `ConstantsLib` but never referenced it, leaving a dead import.

### Fix
Remove the unused `ConstantsLib` import from `DemandLib.sol`. No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)