### PR TITLE
SB-notes: Apply informational audit fixes (N-2 through N-6)

### DIFF
--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -8,7 +8,6 @@ import {StepStorage} from './StepStorage.sol';
 import {Tick, TickStorage} from './TickStorage.sol';
 import {AuctionParameters, IContinuousClearingAuction} from './interfaces/IContinuousClearingAuction.sol';
 import {IValidationHook} from './interfaces/IValidationHook.sol';
-import {IERC20Minimal} from './interfaces/external/IERC20Minimal.sol';
 import {Bid, BidLib} from './libraries/BidLib.sol';
 import {CheckpointAccountingLib} from './libraries/CheckpointAccountingLib.sol';
 import {CheckpointLib} from './libraries/CheckpointLib.sol';
@@ -22,7 +21,6 @@ import {AuctionStep, StepLib} from './libraries/StepLib.sol';
 import {ValidationHookLib} from './libraries/ValidationHookLib.sol';
 import {ValueX7} from './libraries/ValueX7Lib.sol';
 import {IERC165} from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
-import {BlockNumberish} from 'blocknumberish/src/BlockNumberish.sol';
 import {
     ILBPInitializer,
     ILBP_INITIALIZER_INTERFACE_ID,
@@ -173,6 +171,7 @@ contract ContinuousClearingAuction is
     /// @notice Iterate to find the tick where the total demand at and above it is strictly less than the remaining supply in the auction
     /// @dev If the loop reaches the highest tick in the book, `nextActiveTickPrice` will be set to MAX_TICK_PTR
     /// @param _untilTickPrice The tick price to iterate until
+    /// @param _cumulativeMps The cumulative mps unlocked so far
     /// @return The new clearing price
     function _iterateOverTicksAndFindClearingPrice(uint256 _untilTickPrice, uint24 _cumulativeMps)
         internal

--- a/src/StepStorage.sol
+++ b/src/StepStorage.sol
@@ -9,8 +9,8 @@ import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 import {SSTORE2} from 'solady/utils/SSTORE2.sol';
 
 /// @title StepStorage
-/// @notice Abstract contract to store and read information about the auction issuance schedule
-abstract contract StepStorage is BlockNumberish, IStepStorage {
+/// @notice Contract to store and read information about the auction issuance schedule
+contract StepStorage is BlockNumberish, IStepStorage {
     using StepLib for *;
     using SSTORE2 for *;
 

--- a/src/interfaces/IAuctionStorage.sol
+++ b/src/interfaces/IAuctionStorage.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Currency} from '../libraries/CurrencyLibrary.sol';
 import {ValueX7} from '../libraries/ValueX7Lib.sol';
-import {IERC20Minimal} from './external/IERC20Minimal.sol';
 
 /// @notice Interface for auction storage operations
 interface IAuctionStorage {

--- a/src/interfaces/IContinuousClearingAuction.sol
+++ b/src/interfaces/IContinuousClearingAuction.sol
@@ -19,7 +19,7 @@ struct AuctionParameters {
     address fundsRecipient; // address to receive all raised funds
     uint64 startBlock; // Block which the first step starts
     uint64 endBlock; // When the auction finishes
-    uint64 claimBlock; // Block when the auction can claimed
+    uint64 claimBlock; // Block when the auction can be claimed
     uint256 tickSpacing; // Fixed granularity for prices
     address validationHook; // Optional hook called before a bid
     uint256 floorPrice; // Starting floor price for the auction

--- a/src/lens/AuctionStateLens.sol
+++ b/src/lens/AuctionStateLens.sol
@@ -51,13 +51,14 @@ contract AuctionStateLens {
     /// @notice Function which parses the revert reason and returns the AuctionState
     function parseRevertReason(bytes memory reason) internal pure returns (AuctionState memory) {
         if (reason.length != 288) {
-            // Bubble up the revert reason if possible
-            if (reason.length > 32) {
+            // Bubble up any non-empty reason verbatim so the original error selector/data is preserved.
+            // This includes short reasons such as the 4-byte `CheckpointFailed` selector.
+            if (reason.length > 0) {
                 assembly {
                     revert(add(reason, 32), mload(reason))
                 }
             } else {
-                // If the revert reason is too short revert
+                // Only genuinely empty revert data has nothing to bubble up
                 revert InvalidRevertReasonLength();
             }
         }

--- a/src/libraries/CheckpointAccountingLib.sol
+++ b/src/libraries/CheckpointAccountingLib.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.26;
 
 import {Bid, BidLib} from '../libraries/BidLib.sol';
 import {Checkpoint} from '../libraries/CheckpointLib.sol';
-import {FixedPoint96} from '../libraries/FixedPoint96.sol';
 import {ValueX7} from '../libraries/ValueX7Lib.sol';
 import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
 

--- a/src/libraries/DemandLib.sol
+++ b/src/libraries/DemandLib.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ConstantsLib} from './ConstantsLib.sol';
 import {FixedPoint96} from './FixedPoint96.sol';
 import {PriceLib} from './PriceLib.sol';
 import {ValueX7} from './ValueX7Lib.sol';

--- a/src/libraries/ValueX7Lib.sol
+++ b/src/libraries/ValueX7Lib.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {FixedPointMathLib} from 'solady/utils/FixedPointMathLib.sol';
-
 /// @notice A ValueX7 is a uint256 value that has been multiplied by 1e7 (ConstantsLib.MPS)
 /// @dev X7 values are used for demand and supply values to defer division
 type ValueX7 is uint256;

--- a/test/lens/AuctionStateLens.t.sol
+++ b/test/lens/AuctionStateLens.t.sol
@@ -38,6 +38,15 @@ contract AuctionStateLensTest is AuctionUnitTest {
         assertEq(state.isGraduated, expectedIsGraduated);
     }
 
+    /// @notice When the auction's checkpoint reverts, `revertWithState` reverts with the 4-byte
+    /// `CheckpointFailed` selector. `state` must bubble that selector up rather than reverting with
+    /// `InvalidRevertReasonLength` (which previously happened because short reasons were dropped).
+    function test_state_revertsWith_CheckpointFailed_whenCheckpointReverts() public {
+        MockRevertingCheckpointAuction reverting = new MockRevertingCheckpointAuction();
+        vm.expectRevert(AuctionStateLens.CheckpointFailed.selector);
+        lens.state(IContinuousClearingAuction(address(reverting)));
+    }
+
     function test_state_mirrors_checkpoint() public {
         uint256 demand = 1e18 << FixedPoint96.RESOLUTION;
         uint256 price = params.floorPrice + params.tickSpacing;
@@ -66,5 +75,13 @@ contract AuctionStateLensTest is AuctionUnitTest {
         assertEq(state.currencyRaised, expectedCurrencyRaised);
         assertEq(state.totalCleared, expectedTotalCleared);
         assertEq(state.isGraduated, expectedIsGraduated);
+    }
+}
+
+/// @notice Minimal auction whose `checkpoint()` reverts, so `AuctionStateLens.revertWithState`
+/// surfaces `CheckpointFailed`. Only `checkpoint()` is exercised by the lens.
+contract MockRevertingCheckpointAuction {
+    function checkpoint() external pure returns (Checkpoint memory) {
+        revert('checkpoint failed');
     }
 }


### PR DESCRIPTION
## SB-notes — Informational audit fixes

Combines the five SB informational (`N-*`) findings into a single PR. Per our convention, only the behavioral change (N-3) carries a BTT/unit test update; the comment, natspec, keyword, and import-only changes do not. Compiles clean; lens suite passes.

### SB-N-2 — Missing natspec parameter
Added the missing `@param _cumulativeMps` to the natspec for `ContinuousClearingAuction._iterateOverTicksAndFindClearingPrice`. Documentation only.

### SB-N-3 — `AuctionStateLens.state` could not surface `CheckpointFailed` *(behavioral)*
`revertWithState` re-reverts with the 4-byte `CheckpointFailed` selector when `auction.checkpoint()` reverts, but `parseRevertReason` only bubbled up reasons longer than 32 bytes, so the 4-byte selector fell through to `InvalidRevertReasonLength` — making `CheckpointFailed` unreachable from `state()`. Lowered the threshold so any **non-empty** reason is bubbled up verbatim (preserving the original selector/data); `InvalidRevertReasonLength` now only fires on genuinely empty revert data. The 288-byte success-payload check is untouched, so a valid success payload can never be misclassified as an error.
**Test:** added `test_state_revertsWith_CheckpointFailed_whenCheckpointReverts` (with a minimal reverting-checkpoint mock) to `test/lens/AuctionStateLens.t.sol`.

### SB-N-4 — `StepStorage` unnecessarily `abstract`
`StepStorage` implements all its declared methods, so `abstract` was removed (and the title comment updated accordingly).

### SB-N-5 — Comment typo
Fixed "Block when the auction can claimed" → "can be claimed".

### SB-N-6 — Unused imports
Removed unused imports: `IERC20Minimal` and `BlockNumberish` (`ContinuousClearingAuction`), `Currency` and `IERC20Minimal` (`IAuctionStorage`), `FixedPoint96` (`CheckpointAccountingLib`), `ConstantsLib` (`DemandLib`), `FixedPointMathLib` (`ValueX7Lib`). Each verified unreferenced via word-boundary grep.

> **Note:** N-6's removal of `ConstantsLib` from `DemandLib` and `FixedPointMathLib` from `ValueX7Lib` overlaps with the open OZ-notes PR (#352). Both branches delete the identical lines, so they merge cleanly regardless of merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)