### PR TITLE
SB-L-7: Clamp protocol fee to currency raised in sweepCurrency

### DIFF
--- a/snapshots/AuctionTest.json
+++ b/snapshots/AuctionTest.json
@@ -1,5 +1,5 @@
 {
-  "Auction bytecode size": "20382",
+  "Auction bytecode size": "20393",
   "checkpoint_advanceToCurrentStep": "180672",
   "checkpoint_noBids": "166644",
   "checkpoint_zeroSupply": "117018",
@@ -14,6 +14,6 @@
   "submitBid_recordStep_updateCheckpoint_initializeTick": "357405",
   "submitBid_updateCheckpoint": "286957",
   "submitBid_withValidationHook": "361362",
-  "sweepCurrency": "56752",
-  "sweepCurrency_withProtocolFee": "100714"
+  "sweepCurrency": "56778",
+  "sweepCurrency_withProtocolFee": "100740"
 }

--- a/src/ContinuousClearingAuction.sol
+++ b/src/ContinuousClearingAuction.sol
@@ -665,6 +665,9 @@ contract ContinuousClearingAuction is
         uint256 currencyRaised = currencyRaised();
         uint256 protocolFeeAmount =
             ProtocolFeeLib.getProtocolFeeAmount(PROTOCOL_FEE_CONTROLLER, Currency.unwrap(CURRENCY), currencyRaised);
+        // Clamp the protocol fee to the currency raised so a misbehaving fee controller returning a fee
+        // greater than the currency raised cannot underflow the subtraction and permanently brick the sweep
+        if (protocolFeeAmount > currencyRaised) protocolFeeAmount = currencyRaised;
         _sweepCurrency(_getBlockNumberish(), currencyRaised - protocolFeeAmount);
         if (protocolFeeAmount > 0) {
             ProtocolFeeLib.transferProtocolFee(PROTOCOL_FEE_CONTROLLER, Currency.unwrap(CURRENCY), protocolFeeAmount);

--- a/test/btt/auction/sweepCurrency.t.sol
+++ b/test/btt/auction/sweepCurrency.t.sol
@@ -226,6 +226,62 @@ contract SweepCurrencyTest is BttBase {
         assertEq(auction.currencyRaised(), expectedCurrencyRaised);
     }
 
+    function test_WhenProtocolFeeExceedsCurrencyRaised_ClampsToCurrencyRaised(
+        AuctionFuzzConstructorParams memory _params,
+        uint128 _bidAmount,
+        uint256 _excessFee
+    ) public givenAuctionIsGraduated givenNotPreviouslySwept {
+        // it clamps the protocol fee to the currency raised so the sweep cannot underflow and revert
+
+        vm.deal(address(this), type(uint256).max);
+        vm.assume(_bidAmount > 0);
+
+        AuctionFuzzConstructorParams memory mParams = validAuctionConstructorInputs(_params);
+        mParams.token = address(new ERC20Mock());
+        mParams.parameters.currency = address(0);
+        mParams.parameters.requiredCurrencyRaised = 0;
+        mParams.parameters.validationHook = address(0);
+        mParams.parameters.fundsRecipient = makeAddr('fundsRecipient');
+
+        address protocolFeeRecipient = makeAddr('protocolFeeRecipient');
+        MockProtocolFeeController protocolFeeController = new MockProtocolFeeController();
+        protocolFeeController.setProtocolFeeRecipient(protocolFeeRecipient);
+
+        MockContinuousClearingAuction auction = new MockContinuousClearingAuction(
+            mParams.token, mParams.totalSupply, mParams.parameters, address(protocolFeeController)
+        );
+
+        ERC20Mock(mParams.token).mint(address(auction), requiredTokenDeposit(mParams));
+        auction.onTokensReceived();
+
+        vm.roll(mParams.parameters.startBlock);
+
+        uint256 maxPrice = mParams.parameters.floorPrice + mParams.parameters.tickSpacing;
+        auction.submitBid{value: _bidAmount}(maxPrice, _bidAmount, address(this), bytes(''));
+
+        vm.roll(mParams.parameters.endBlock);
+        auction.checkpoint();
+        uint256 expectedCurrencyRaised = auction.currencyRaised();
+        vm.assume(expectedCurrencyRaised > 0);
+
+        // A misbehaving controller returns a fee strictly greater than the currency raised
+        _excessFee = bound(_excessFee, 1, type(uint128).max);
+        protocolFeeController.setProtocolFeeAmount(expectedCurrencyRaised + _excessFee);
+
+        // The fee is clamped to the currency raised: the full amount is transferred as the protocol fee,
+        // zero is swept to the funds recipient, and the sweep succeeds instead of underflowing and reverting.
+        vm.expectEmit(true, true, true, true);
+        emit IAuctionStorage.CurrencySwept(mParams.parameters.fundsRecipient, 0);
+        vm.expectEmit(true, true, true, true);
+        emit ProtocolFeeLib.ProtocolFeeTransferred(address(0), expectedCurrencyRaised);
+        vm.prank(mParams.parameters.fundsRecipient);
+        auction.sweepCurrency();
+
+        assertEq(auction.sweepCurrencyBlock(), block.number);
+        assertEq(protocolFeeRecipient.balance, expectedCurrencyRaised);
+        assertEq(mParams.parameters.fundsRecipient.balance, 0);
+    }
+
     function test_WhenAmountEQZero(AuctionFuzzConstructorParams memory _params)
         public
         givenAuctionIsGraduated

--- a/test/btt/auction/sweepCurrency.tree
+++ b/test/btt/auction/sweepCurrency.tree
@@ -14,7 +14,9 @@ SweepCurrencyTest
             │   ├── it writes sweepCurrencyBlock
             │   ├── it transfers amount currency to funds recipient
             │   └── it emits {CurrencySwept}
-            └── when amount EQ zero
-                ├── it writes sweepCurrencyBlock
-                ├── it does not transfer amount currency to funds recipient
-                └── it emits {CurrencySwept}
+            ├── when amount EQ zero
+            │   ├── it writes sweepCurrencyBlock
+            │   ├── it does not transfer amount currency to funds recipient
+            │   └── it emits {CurrencySwept}
+            └── when protocol fee exceeds currency raised
+                └── it clamps the fee to the currency raised so the sweep cannot underflow and revert


### PR DESCRIPTION
## SB-L-7 — `sweepCurrency` DoS via misbehaving protocol fee controller

### Issue
`ContinuousClearingAuction.sweepCurrency` queries `PROTOCOL_FEE_CONTROLLER` at sweep time and computed `currencyRaised - protocolFeeAmount` with no bounds check. A misbehaving or misconfigured controller returning `protocolFeeAmount > currencyRaised` underflows the subtraction and reverts — **permanently bricking the sweep** (`sweepCurrencyBlock` is never set, so it can never succeed).

### Fix
Clamp `protocolFeeAmount` to `currencyRaised` before the subtraction (the recommended fix):
```solidity
if (protocolFeeAmount > currencyRaised) protocolFeeAmount = currencyRaised;
```
The sweep then always proceeds: the full raised amount is transferred as the protocol fee and zero is swept to the funds recipient. Severity is Low because the fee controller is a trusted, protocol-set address; impact is DoS of fund sweeping, not theft.

### Test
Added BTT fuzz case `test_WhenProtocolFeeExceedsCurrencyRaised_ClampsToCurrencyRaised` (2500 runs) asserting the sweep succeeds and clamps when the controller returns a fee greater than `currencyRaised`, plus the corresponding `sweepCurrency.tree` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)